### PR TITLE
Implement ellipsis and increase padding for long card desc

### DIFF
--- a/src/js/components/Posts.js
+++ b/src/js/components/Posts.js
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom';
 import { loadPosts, states, blogUrl } from '../services/api'
 import { ago, isNewer, TIME_UNITS } from '../services/dates'
 
+const POST_TITLE_MAX_LENGTH = 70
+
 export default class BlogPostsContainer extends Component {
   constructor(props) {
     super(props)
@@ -53,7 +55,7 @@ function Post({ post, first }) {
                 <figure>
                     <CardHeaderImage url={post.featured_image} />
                 </figure>
-                <h1>{post.title}</h1>
+                <h1>{ellipsis(post.title+post.title, POST_TITLE_MAX_LENGTH)}</h1>
             </header>
             <footer>
                 <img src={post.author_avatar} />
@@ -81,4 +83,23 @@ function CardHeaderImage({url}) {
         </div>
       )
   }
+}
+
+function ellipsis(text, maxLenght) {
+  if (text.length <= maxLenght) {
+    return text;
+  }
+
+  let cutterPosition = text.indexOf(' ', maxLenght - 1)
+  if (cutterPosition == -1) {
+    return text;
+  }
+
+  const lastChar = text[cutterPosition - 1]
+  const removedFromTheEndChars = '.,'
+  if (removedFromTheEndChars.indexOf(lastChar) > -1) {
+    cutterPosition--
+  }
+
+  return text.slice(0, cutterPosition) + '\u2026';
 }

--- a/src/sass/components/cards.scss
+++ b/src/sass/components/cards.scss
@@ -76,7 +76,7 @@
 
         p {
             @include text-normal;
-            padding: 0 $padding-card $padding-card;
+            padding: 0 $padding-card ($size-card-arrow + 2 * $padding-card);
         }
 
         footer {


### PR DESCRIPTION
Ellipsis feature for blog titles:
- 70 chars max
- if text.length > 70 -> cropp after **next** word, adding an `&hellip;`
- if last char &mdash;after cropping&mdash; is a `.` or `,` remove it.
![image](https://user-images.githubusercontent.com/2437584/27181595-81aeeb9e-51d8-11e7-93ab-b4abe9653e17.png)

Increase padding feature:
- The text of the project cards will not overlap the arrow
![image](https://user-images.githubusercontent.com/2437584/27181629-ac24586e-51d8-11e7-9970-12486ba8fea5.png)
