### PR TITLE
Add as-is class

### DIFF
--- a/hugo/data/home/home.yml
+++ b/hugo/data/home/home.yml
@@ -1,4 +1,4 @@
-title: "Building the technological stack for AI on code"
+title: "Building the technological stack for <span class='as-is'>AI</span> on code"
 desc: "source{d} is building the open-source components that enable machine learning on source code. We believe that the next step in programming comes from teaching machines to understand and write code."
 links:
   roadmap:

--- a/hugo/layouts/partials/home/hero.html
+++ b/hugo/layouts/partials/home/hero.html
@@ -4,8 +4,8 @@
         <img class="code-pills-right" src="{{ "img/bgs/codepills-bg-4.png" | absURL }}" />
 
         <div class="home-hero__info">
-            <h1>{{ .title }}</h1>
-            <p>{{ .desc }}</p>
+            <h1>{{ .title | safeHTML }}</h1>
+            <p>{{ .desc | safeHTML }}</p>
             <div class="home-hero__info__links">
                 {{ partial "home/our-links.html" . }}
             </div>

--- a/src/sass/shared/app.scss
+++ b/src/sass/shared/app.scss
@@ -4,6 +4,7 @@
 @import "languages";
 @import "mixins";
 @import "typefaces";
+@import "global";
 
 @import "grid";
 @import "skeleton";

--- a/src/sass/shared/global.scss
+++ b/src/sass/shared/global.scss
@@ -1,0 +1,7 @@
+/*
+ * Global classes that can be used whenever and wherever.
+ */
+
+.as-is {
+    text-transform: none !important;
+}


### PR DESCRIPTION
Text is supposed to be transformed lowercase but there are some terms
that would need to look as they were written. For most of them, it does
not really matter whether they are Capitalized, UPPERCASE or lowercase.
But for some of them, it can affect legibility (AI, etc.).

By adding the class `as-is`, anyone will be able to keep the case of
a texts prepared to be rendered as HTML.