### PR TITLE
Fix button-pill height and background

### DIFF
--- a/src/sass/components/buttons.scss
+++ b/src/sass/components/buttons.scss
@@ -1,6 +1,7 @@
 .btn-pill {
   @include pill-style(blue);
-  line-height: $height-pill-buttons;
+  line-height: $height-pill-buttons - 2 * $border-width-pills;
+  background-color: transparent;
   font-size: $font-size-pill-button;
   padding: 0 $padding-pill-button-sides;
 

--- a/src/sass/shared/mixins.scss
+++ b/src/sass/shared/mixins.scss
@@ -98,7 +98,7 @@
 
 @mixin pill-style($type: blue) {
     @include transition(background-color color border-color box-shadow);
-    border-width: 2px;
+    border-width: $border-width-pills;
     border-style: solid;
     border-radius: 45px;
     text-align: center;

--- a/src/sass/shared/variables.scss
+++ b/src/sass/shared/variables.scss
@@ -140,6 +140,7 @@ $padding-roadmap-signature-name-bottom: $gutter-size / 2;
 
 // Heights and widths
 $height-pill-buttons: 45px;
+$border-width-pills: 2px;
 
 $height-title-big-pill: 15px;
 $width-title-big-pill: 90px;


### PR DESCRIPTION
This commit fixes two things:

## Height

Currently, the height was 4px over the documented height. This was
because for centering the text we are using the line-height trick with
the final height, this adds two times the border-width to the height.

## Background color

The background color needs to be transparent and not inherit. They
behave the same as long as the background-color does not contain
opacity.