### PR TITLE
Improve pills styles

### DIFF
--- a/src/sass/shared/mixins.scss
+++ b/src/sass/shared/mixins.scss
@@ -112,7 +112,7 @@
     @include transition(background-color color border-color box-shadow fill);
     border-width: $border-width-pills;
     border-style: solid;
-    border-radius: 45px;
+    border-radius: $border-radius-pill-style;
     text-align: center;
     display: inline-block;
     text-decoration: none;
@@ -126,8 +126,17 @@
         border-color: $color-pill-button-white-main;
     }
 
-    &:hover {
-      @include pill-style-hover($type)
+    // Using both the semantic way and the global modifier way.
+    &:hover:not(:disabled),
+    &:hover:not(.disabled) {
+        @include pill-style-hover($type)
+    }
+
+    // Using both the semantic way and the global modifier way.
+    &:disabled,
+    &.disabled {
+        cursor: not-allowed;
+        opacity: 0.3;
     }
 }
 

--- a/src/sass/shared/variables.scss
+++ b/src/sass/shared/variables.scss
@@ -125,7 +125,7 @@ $margin-hero-desc-vertical: 30px;
 $padding-hero-vertical: 90px;
 $padding-section-vertical: $column-size;
 
-$padding-pill-button-sides: 60px;
+$padding-pill-button-sides: 25px; //$height-pill-buttons / 2;
 
 $padding-terminal-header-vertical: $gutter-size / 3;
 $padding-terminal-header-horizontal: $gutter-size / 2;
@@ -210,6 +210,7 @@ $size-codepill-project-vertical-correction: $size-codepills-project-height * $si
 
 // Radius
 $border-radius-main: 5px;
+$border-radius-pill-style: $height-pill-buttons / 2;
 
 // Shadows
 $shadow-main: 3px 3px 5px rgba(0, 0, 0, .1);


### PR DESCRIPTION
This PR improves the styling for pills.

Pills can have a disabled stated in two different ways:

- Using the `.disabled` class (a global modifier).
- Using the `disabled="disabled"` attribute for those elements that
  accept it.