### PR TITLE
Fix alignment between hero and rest of the page.

### DIFF
--- a/hugo/layouts/partials/home/hero.html
+++ b/hugo/layouts/partials/home/hero.html
@@ -1,8 +1,5 @@
 <header class="home-hero">
     <div class="home-hero__wrap">
-        <img class="code-pills-left" src="{{ "img/bgs/codepills-bg-1.png" | absURL }}" />
-        <img class="code-pills-right" src="{{ "img/bgs/codepills-bg-4.png" | absURL }}" />
-
         <div class="home-hero__info">
             <h1>{{ .title | safeHTML }}</h1>
             <p>{{ .desc | safeHTML }}</p>
@@ -24,5 +21,7 @@
              data-title="{{ .slack.title }}"
              data-wait="{{ .slack.msgs.wait }}"
         ></div>
+        <img class="code-pills-left" src="{{ "img/bgs/codepills-bg-1.png" | absURL }}" />
+        <img class="code-pills-right" src="{{ "img/bgs/codepills-bg-4.png" | absURL }}" />
     </div>
 </header>


### PR DESCRIPTION
Currently, containers first child margin-left is reduced to 0. This was
not happening in hero because the content is not the first child.

In this case it is easily fixable, but in other case a by-hand fix might
need to be applied 😢 