### PR TITLE
Fix team/person picture in FireFox

### DIFF
--- a/hugo/layouts/partials/team/person-circle.svg
+++ b/hugo/layouts/partials/team/person-circle.svg
@@ -1,4 +1,6 @@
-<svg class="person-circle" viewbox="0,0,200,220">
+<svg class="person-circle"viewbox="0,0,200,220"
+    width="200px" height="220px"
+>
     <circle class="person-circle__background" cx="100" cy="120" r="100" fill="green" />
     <path class="person-circle__border person-circle__border_upper" d="
             M 198,120
@@ -6,7 +8,9 @@
     " />
 
     <image class="person-circle__image"
-        width="135%" x="-35" y="-30"
+        x="-40px" y="-30px"
+        width="280px" height="1000px"
+        preserveAspectRatio="xMinYMin"
         clip-path="url(#circleView)"
         xlink:href="/img/people/{{.}}"
     />

--- a/src/sass/pages/team.scss
+++ b/src/sass/pages/team.scss
@@ -7,8 +7,6 @@
         &__section__group__item__picture-area {
             display: block;
             position: relative;
-            width: $width-person-card-image;
-            height: $height-person-card-image;
             margin: 0 auto;
             cursor: pointer;
         }
@@ -42,16 +40,6 @@
 }
 
 .person-circle {
-    $image-width: $ratio-person-card-image * $width-person-card-image;
-    width: $width-person-card-image;
-    height: $height-person-card-image;
-
-    image.person-circle__image {
-        x: - ($image-width - $width-person-card-image) / 2;
-        y: $margin-top-person-card-image;
-        width: $image-width;
-    }
-
     &__background {
         fill: $color-card-background;
     }

--- a/src/sass/shared/variables.scss
+++ b/src/sass/shared/variables.scss
@@ -299,9 +299,6 @@ $size-team-social: 30px;
 $size-team-social-shift: -5px;
 
 $max-width-circles-info: 240px;
-$ratio-person-card-image: 1.4;
-$width-person-card-image: 200px;
-$height-person-card-image: 220px;
 
 $height-stack-pipeline: 45px;
 $width-stack-pipeline: 28px;
@@ -395,7 +392,6 @@ $size-circles-between-groups: 60px;
 $size-circles-below-group-name: 45px;
 $size-circles-above-item-title: 15px;
 $size-circles-below-item-title: 15px;
-$margin-top-person-card-image: -30px;
 
 $size-stack-between-groups: 120px;
 $size-stack-below-group-name: 60px;


### PR DESCRIPTION
Fix issue in Firefox because it does not:
- recognize `x`, `y` css  properties for `svg>image`
- `<image>` tag must have height and width