### PR TITLE
Fix lower bound image overflow in person-circle

### DIFF
--- a/hugo/layouts/partials/team/person-circle.svg
+++ b/hugo/layouts/partials/team/person-circle.svg
@@ -1,7 +1,7 @@
 <svg class="person-circle"viewbox="0,0,200,220"
     width="200px" height="220px"
 >
-    <circle class="person-circle__background" cx="100" cy="120" r="100" fill="green" />
+    <circle class="person-circle__background" cx="100" cy="120" r="100" />
     <path class="person-circle__border person-circle__border_upper" d="
             M 198,120
             a -98,-98 0 0,0 -196,0

--- a/src/sass/shared/variables.scss
+++ b/src/sass/shared/variables.scss
@@ -452,5 +452,5 @@ $transition-main-time: .3s;
 $transition-main-effect: ease-in;
 
 // Borders
-$border-width-person-card: 4px;
+$border-width-person-card: 5px;
 $border-person-card: $border-width-person-card solid $color-lightest-grey;


### PR DESCRIPTION
In people's circle, the image was being shown a bit below the lower
bound. This trick is a bit nasty, but fixes the problem.

In this image it is clear that is the image leaking and not a shadow efect: see how it matches the void between arm and body.

![2017-07-31 at 11 39](https://user-images.githubusercontent.com/36221/28774522-1a05fc46-75ee-11e7-89de-e90c3e0a6d24.png)
