### PR TITLE
Fix problem with cards in safari

### DIFF
--- a/src/sass/components/cards.scss
+++ b/src/sass/components/cards.scss
@@ -44,9 +44,12 @@
             figure {
                 display: flex;
                 align-items: center;
-                justify-content: center;
                 position: relative;
                 height: $size-card-image-height;
+
+                .svg-icon {
+                    margin: 0 auto;
+                }
 
                 svg {
                     width: $size-card-proy-logo;


### PR DESCRIPTION
In safari, blog cards had the image over half way through the card. This
is fixed by removing the `justify-content` from the `figure` selector.
The margin centering is for cards with svg icons.

![2017-07-31 at 13 52](https://user-images.githubusercontent.com/36221/28776614-9eba1202-75f7-11e7-93ef-87efadc25052.png)