### PR TITLE
Add certificates to api image

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,7 @@
 FROM alpine:3.6
 
+RUN apk --update add ca-certificates
+
 COPY bin /bin/
 
 CMD ["/bin/api"]


### PR DESCRIPTION
External https requests, e.g. lever, will fail otherwise

```
[GIN] 2017/08/25 - 14:01:08 | 500 |  373.204336ms |      83.35.2.97 | GET      /api/positions
Error #01: Get https://api.lever.co/v0/postings/sourced?mode=json: x509: failed to load system roots and no roots provided
```