### PR TITLE
Helm chart

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -3,6 +3,11 @@
     log stdout
     gzip
 
+    redir 301 {
+        if {>X-Forwarded-Proto} is http
+        /  https://{host}{uri}
+    }
+
     ext .html
     errors stdout {
         404 404.html

--- a/helm-charts/landing/.helmignore
+++ b/helm-charts/landing/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm-charts/landing/Chart.yaml
+++ b/helm-charts/landing/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: landing
+version: 0.1.0

--- a/helm-charts/landing/README.md
+++ b/helm-charts/landing/README.md
@@ -1,0 +1,39 @@
+# Landing
+
+This chart deploys [landing](https://github.com/src-d/landing) source{d} web page
+
+## Pre-requisites
+
+* Kubernetes 1.4+ with Beta APIs enabled
+
+## Installing the chart
+
+All parameters under `settings` in [values.yaml](/landing/values.yaml) must be provided.
+
+```
+helm install -n <release-name> <chart path> --set "\
+image.landingSlackin.slackApiToken=TOKEN\
+ingress.hosts={srcd.run,www.srcd.run},\
+ingress.globalStaticIpName=landing-srcd-run,\
+image.tag=your-favourite.tag\
+```
+
+These are the mandatory parameters that need to be provided or installation will fail.
+Other parameters can be provided too but, if not, a default value will be used.
+
+# Configuration
+
+Please refer to [values.yaml](values.yaml) for the full run-down on defaults.
+
+To override any of those default values,
+specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided
+while installing the chart.
+For example,
+
+```bash
+$ helm install --name <release-name> -f values.yaml <path-to-chart>
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/helm-charts/landing/templates/_helpers.tpl
+++ b/helm-charts/landing/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm-charts/landing/templates/deployment.yaml
+++ b/helm-charts/landing/templates/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Values.image.landing.name }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.landing.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.landing.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.landing.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.landing.internalPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        - name: {{ .Values.image.landingSlackin.name }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.landingSlackin.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: SLACK_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: slack-api-token
+          ports:
+            - containerPort: {{ .Values.service.landingSlackin.internalPort }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.landingSlackin.internalPort }}
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.service.landingSlackin.internalPort }}
+            initialDelaySeconds: 5
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        - name: {{ .Values.image.landingApi.name }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.landingApi.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: ADDR
+              value: ":{{ .Values.service.landingApi.internalPort }}"
+            - name: SLACKIN_URL
+              value: "http://localhost:{{ .Values.service.landingSlackin.internalPort }}/invite"
+          ports:
+            - containerPort: {{ .Values.service.landingApi.internalPort }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.landingApi.internalPort }}
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.service.landingApi.internalPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/helm-charts/landing/templates/ingress.yaml
+++ b/helm-charts/landing/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- $serviceName := include "fullname" . -}}
+{{- $slackinPort := .Values.service.landingSlackin.externalPort -}}
+{{- $apiPort := .Values.service.landingApi.externalPort -}}
+{{- $landingPort := .Values.service.landing.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+      kubernetes.io/ingress.global-static-ip-name: {{ required "Missing .Values.ingress.globalStaticIpName" .Values.ingress.globalStaticIpName }}
+spec:
+  rules:
+  # Cannot specify multiple hosts. See https://github.com/kubernetes/kubernetes/issues/43633
+  {{- range $host :=  required "Missing .Values.ingress.hosts" .Values.ingress.hosts }}
+  - host: {{ $host }}
+    http:
+      paths:
+        - backend:
+            serviceName: {{ $serviceName }}
+            servicePort: {{ $landingPort }}
+          path: /*
+        - backend:
+            serviceName: {{ $serviceName }}
+            servicePort: {{ $slackinPort }}
+          path: /slackin/*
+        - backend:
+            serviceName: {{ $serviceName }}
+            servicePort: {{ $apiPort }}
+          path: /api/*
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - secretName: "{{ template "fullname" . }}-tls"
+      hosts:
+      {{- range $host :=  required "Missing .Values.ingress.hosts" .Values.ingress.hosts }}
+        - {{ $host }}
+      {{- end }}
+  {{- end }}

--- a/helm-charts/landing/templates/secrets.yaml
+++ b/helm-charts/landing/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  slack-api-token: {{ required "Missing .Values.image.landingSlackin.slackApiToken" .Values.image.landingSlackin.slackApiToken | b64enc | quote }}

--- a/helm-charts/landing/templates/service.yaml
+++ b/helm-charts/landing/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.landing.externalPort }}
+      targetPort: {{ .Values.service.landing.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.landing.name }}
+    - port: {{ .Values.service.landingSlackin.externalPort }}
+      targetPort: {{ .Values.service.landingSlackin.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.landingSlackin.name }}
+    - port: {{ .Values.service.landingApi.externalPort }}
+      targetPort: {{ .Values.service.landingApi.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.landingApi.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/helm-charts/landing/values.yaml
+++ b/helm-charts/landing/values.yaml
@@ -1,0 +1,57 @@
+# Default values for landing.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+# If provided, these will be used by the deployment
+# nodeSelector: XXXXXXX
+
+image:
+  # same tag for everyone as it is how landing repo Makefile works
+  tag: master
+  pullPolicy: IfNotPresent
+  registry: quay.io/srcd
+  landing:
+    name: landing
+  landingSlackin:
+    name: landing-slackin
+    # slackingApiToken: required
+  landingApi:
+    name: landing-api
+service:
+  type: NodePort
+  landing:
+    externalPort: 8090
+    internalPort: 8090
+    name: landing
+  landingSlackin:
+    externalPort: 3000
+    internalPort: 3000
+    name: landing-slackin
+  landingApi:
+    externalPort: 8080
+    internalPort: 8080
+    name: landing-api
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/tls-acme: "true"
+  tls: true
+  # below values are required
+  # hosts:
+  # - sourced.tech
+  # - www.sourced.tech
+  # globalStaticIpName: "landing-ip"
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #


### PR DESCRIPTION
Deployed using manually built images from PR #133 (with below Caddyfile redirection added by hand). This PR must not be merged until that one is.

http://srcd.run
http://www.srcd.run

```
helm install -n landing . --set "\
image.landingSlackin.slackApiToken=TOKEN,\
ingress.hosts={srcd.run,www.srcd.run},\
ingress.globalStaticIpName=landing-srcd-run,\
image.registry=quay.io/rporres,\
image.tag=healthcheck-api
"