### PR TITLE
Fix DOCKER_ORG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 env:
   global:
     - DOCKER_REGISTRY: quay.io
-    - DOCKER_ORG: quay.io/srcd
+    - DOCKER_ORG: srcd
 
 matrix:
   allow_failures:


### PR DESCRIPTION
After https://github.com/src-d/ci/commit/4d6f93fb2728b0c42bcde1a34f143fcf6aa9fe94 the `$DOCKER_ORG` must be only `srcd` to fit the [ci/Makefile.main#L108](https://github.com/src-d/ci/blob/master/Makefile.main#L108)