### PR TITLE
Enhance slack form error message

### DIFF
--- a/hugo/data/slack.yml
+++ b/hugo/data/slack.yml
@@ -5,5 +5,7 @@ endpoint: "/invite"
 msgs:
   success: Success! Check your email.
   button: Join us on slack
-  server_error: Error! Submit it again.
+  server_error: "Oops, something went wrong on our side!
+
+  Please message us via [email](mailto:hello@sourced.tech) or [twitter](https://twitter.com/srcd_) and we will send your invitation soon."
   fetch_error: Server error

--- a/hugo/layouts/partials/slack.html
+++ b/hugo/layouts/partials/slack.html
@@ -14,8 +14,8 @@
     data-placeholder="{{ .slack.placeholder }}"
     data-endpoint="{{ .slack.endpoint }}"
 
-    data-success="{{ .slack.msgs.success }}"
     data-button="{{ .slack.msgs.button }}"
+    data-success="{{ .slack.msgs.success }}"
     data-server-error="{{ .slack.msgs.server_error }}"
     data-fetch-error="{{ .slack.msgs.fetch_error }}"
     >

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lightbox2": "^2.9.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
+    "react-markdown": "^2.5.0",
     "slick-carousel": "1.6.0",
     "whatwg-fetch": "^2.0.0"
   },

--- a/src/js/components/SlackForm.js
+++ b/src/js/components/SlackForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactMarkdown from 'react-markdown';
 import { inviteToSlack } from '../services/api';
 import { gaPromise as ga } from '../services/link_track';
 
@@ -180,9 +181,11 @@ export default class SlackForm extends React.Component {
             {this.props.button}
           </button>
 
-          <p className={this.messageClasses}>
-            {this.responseMessage}
-          </p>
+          <ReactMarkdown
+            source={this.responseMessage}
+            className={this.messageClasses}
+            softBreak="br"
+          />
         </div>
       </form>
     );

--- a/src/sass/components/footer.scss
+++ b/src/sass/components/footer.scss
@@ -4,10 +4,11 @@
     &__slack {
         @include row;
         width: initial;
-        margin-right: 0;
+        margin-right: auto;
+        margin-left: auto;
         margin-top: $margin-top-footer-slack;
+        padding-bottom: $size-slack-form-horizontal-message-spacing;
         background-color: $color-footer-slack-band-bg;
-        height: $size-footer-slack-band;
 
         .slack-form__wrap {
             @include container;
@@ -113,7 +114,6 @@
     .footer {
         &__slack {
             margin: 0;
-            height: auto;
             padding: $padding-section-vertical-mobile 0;
         }
     }

--- a/src/sass/components/slack-form.scss
+++ b/src/sass/components/slack-form.scss
@@ -8,23 +8,16 @@
         color: $color-slack-form-description;
         text-align: center;
         text-transform: lowercase;
-        margin-bottom: ($height-slack-form-input / 2 ) +
-        $margin-bottom-slack-form-input +
-        $height-pill-buttons +
-        $margin-bottom-slack-form-submit-button +
-        $height-slack-form-message +
-        $margin-bottom-slack-form-message;
+        margin-bottom: 0;
     }
 
     &__logo {
         margin: auto;
         margin-top: $margin-top-slack-form-logo;
-        margin-bottom: $margin-bottom-slack-form-logo;
         height: $height-slack-form-logo;
     }
 
     &__title {
-        margin-bottom: $margin-bottom-slack-form-title;
         color: $color-light-blue;
         font-family: $font-titles;
         font-size: $font-size-slack-form-title;
@@ -39,7 +32,7 @@
     }
 
     &__body {
-        position: absolute;
+        position: relative;
         bottom: 0;
         left: 0;
         width: 100%;
@@ -62,27 +55,25 @@
     &__input {
         @include input(white);
         display: block;
-        margin: -($height-slack-form-input / 2) auto $margin-bottom-slack-form-input auto;
+        margin: 0;
         width: calc(100% - #{2 * $padding-lateral-slack-form});
     }
 
     &__submit {
         display: block;
-        margin: 0 auto $margin-bottom-slack-form-submit-button;
+        margin: 0 auto;
         width: $width-slack-form-submit;
     }
 
     &__message {
-        height: $height-slack-form-message;
-        margin: 0 auto $margin-bottom-slack-form-message;
-        text-align: center;
+        font-size: $font-size-slack-band-message;
 
         &_hidden {
             visibility: hidden;
         }
 
-        &_success {
-            @include svg-icon('message-icon-success', 30px, 30px) {
+        &_success p {
+            @include svg-icon('message-icon-success', $size-slack-form-message-icon, $size-slack-form-message-icon) {
                 border-radius: 50%;
                 border-style: solid;
                 border-color: $color-pill-button-white-main;
@@ -90,14 +81,38 @@
                 margin-right: $margin-right-slack-form-message-icon;
             }
         }
+    }
 
-        &_error {
-            @include svg-icon('message-icon-error-face', 30px, 30px) {
-                border-radius: 50%;
-                border-style: solid;
-                border-color: $color-pill-button-white-main;
-                border-width: $border-width-pills;
-                margin-right: $margin-right-slack-form-message-icon;
+    &--vertical {
+        .slackForm {
+            &__body {
+                padding-top: calc( #{$height-slack-form-input} / 2 + #{$padding-top-hero-slack} );
+                padding-bottom: $padding-top-hero-slack;
+            }
+
+            &__logo {
+                margin-bottom: $margin-bottom-slack-form-logo;
+            }
+
+            &__title {
+                margin-bottom: $margin-bottom-slack-form-title;
+            }
+
+            &__input {
+                position: absolute;
+                margin: 0 auto;
+                top: calc( -#{$height-slack-form-input} / 2 );
+                left: 50%;
+                transform: translateX(-50%);
+            }
+
+            &__message {
+                margin: 0 $padding-top-hero-slack;
+                text-align: center;
+
+                & > p {
+                    padding-top: $padding-top-hero-slack;
+                }
             }
         }
     }
@@ -121,8 +136,7 @@
 
             &__logo {
                 @include columns(2);
-                margin-top: 40px;
-                margin-bottom: 0;
+                margin-top: $size-slack-form-horizontal-message-spacing;
                 margin-left: 0;
                 display: inline;
                 height: $size-footer-slack-logo;
@@ -131,10 +145,11 @@
 
             &__title {
                 @include columns(3);
-                margin: 0 auto;
-                line-height: $size-footer-slack-band;
+                margin-top: $size-slack-form-horizontal-message-spacing;
+                line-height: $height-slack-form-input;
                 font-size: $font-size-footer-slack-band-title;
                 color: $color-footer-slack-band-title;
+                text-align: left;
             }
 
             &__description {
@@ -142,7 +157,6 @@
             }
 
             &__body {
-                position: static;
                 display: inline;
                 background: transparent;
             }
@@ -160,41 +174,27 @@
             }
 
             &__message {
-                @include columns(3);
-                position: absolute;
-                right: $size-footer-slack-band-right-distance;
-                bottom: $size-footer-slack-band-bottom-distance;
-                text-align: center;
+                @include columns(7);
+                @include offset(5);
+                text-align: left;
                 color: white;
-                font-size: $font-size-slack-band-message;
+                transform: translateX(-$gutter-size);
 
-                &:before {
-                    height: $height-slack-form-horizontal-message !important;
-                    width: $height-slack-form-horizontal-message !important;
+                & > p {
+                    padding-top: $padding-top-slack-form-horizontal-message;
                 }
 
                 &_hidden {
                     visibility: hidden;
                 }
 
-                &_success {
-                    @include svg-icon('message-icon-success', 30px, 30px) {
+                &_success p {
+                    @include svg-icon('message-icon-success', $size-slack-form-message-icon, $size-slack-form-message-icon) {
                         border-radius: 50%;
                         border-style: solid;
                         border-color: $color-footer-slack-band-success-border;
                         border-width: $width-footer-slack-band-message-icon-border;
                         background-color: $color-footer-slack-band-success-bg;
-                        margin-right: $margin-right-slack-form-message-icon;
-                    }
-                }
-
-                &_error {
-                    @include svg-icon('message-icon-error-face', 30px, 30px) {
-                        border-radius: 50%;
-                        border-style: solid;
-                        border-color: $color-footer-slack-band-error-border;
-                        border-width: $width-footer-slack-band-message-icon-border;
-                        background-color: $color-footer-slack-band-error-bg;
                         margin-right: $margin-right-slack-form-message-icon;
                     }
                 }
@@ -270,9 +270,12 @@
 
             &__message {
                 width: 100%;
-                margin: 0;
+                max-width: $width-slack-form-horizontal-input-mobile;
+                margin: 0 auto;
                 right: 0;
-                bottom: $size-slack-form-horizontal-message-spacing;
+                float: none;
+                text-align: center;
+                transform: none;
             }
 
             &__logo {

--- a/src/sass/components/slack-form.scss
+++ b/src/sass/components/slack-form.scss
@@ -41,6 +41,10 @@
 
         &_success {
             background-color: $color-slack-form-body-success-bg;
+
+            button {
+                display: none !important;
+            }
         }
 
         &_error {
@@ -80,6 +84,8 @@
                 border-width: $border-width-pills;
                 margin-right: $margin-right-slack-form-message-icon;
             }
+
+            line-height: $height-slack-form-input;
         }
     }
 
@@ -110,7 +116,7 @@
                 margin: 0 $padding-top-hero-slack;
                 text-align: center;
 
-                & > p {
+                &_error > p {
                     padding-top: $padding-top-hero-slack;
                 }
             }
@@ -164,13 +170,13 @@
             &__input {
                 @include columns(4);
                 display: inline;
-                margin-top: ($size-footer-slack-band - $size-footer-slack-input) / 2;
+                margin-top: $size-slack-form-horizontal-message-spacing;
             }
 
             &__submit {
                 @include columns(3);
                 display: inline;
-                margin-top: ($size-footer-slack-band - $size-footer-slack-input) / 2;
+                margin-top: $size-slack-form-horizontal-message-spacing;
             }
 
             &__message {
@@ -180,23 +186,31 @@
                 color: white;
                 transform: translateX(-$gutter-size);
 
-                & > p {
-                    padding-top: $padding-top-slack-form-horizontal-message;
-                }
-
                 &_hidden {
                     visibility: hidden;
                 }
 
-                &_success p {
-                    @include svg-icon('message-icon-success', $size-slack-form-message-icon, $size-slack-form-message-icon) {
-                        border-radius: 50%;
-                        border-style: solid;
-                        border-color: $color-footer-slack-band-success-border;
-                        border-width: $width-footer-slack-band-message-icon-border;
-                        background-color: $color-footer-slack-band-success-bg;
-                        margin-right: $margin-right-slack-form-message-icon;
+                &_success {
+                    width: auto;
+                    height: $height-slack-form-input;
+                    margin-top: $size-slack-form-horizontal-message-spacing;
+                    margin-left: $gutter-size;
+                    transform: none;
+
+                    p {
+                        @include svg-icon('message-icon-success', $size-slack-form-message-icon, $size-slack-form-message-icon) {
+                            border-radius: 50%;
+                            border-style: solid;
+                            border-color: $color-footer-slack-band-success-border;
+                            border-width: $width-footer-slack-band-message-icon-border;
+                            background-color: $color-footer-slack-band-success-bg;
+                            margin-right: $margin-right-slack-form-message-icon;
+                        }
                     }
+                }
+
+                &_error p {
+                    padding-top: $padding-top-slack-form-horizontal-message;
                 }
             }
         }
@@ -276,6 +290,10 @@
                 float: none;
                 text-align: center;
                 transform: none;
+
+                &_success {
+                    margin-top: $margin-top-slack-form-horizontal-elements;
+                }
             }
 
             &__logo {

--- a/src/sass/definitions/variables.scss
+++ b/src/sass/definitions/variables.scss
@@ -205,8 +205,6 @@ $size-title-footer-spacing: $gutter-size / 3 - 1px;
 //..
 $height-slack-form-logo: 50px;
 $height-slack-form-input: 45px;
-$height-slack-form-message: 30px;
-$height-slack-form-horizontal-message: 20px;
 $width-slack-form-submit: 240px;
 //..
 $size-button-spacing: $gutter-size / 2;
@@ -282,8 +280,6 @@ $size-footer-slack-band: 120px;
 $size-footer-slack-logo: 46px;
 $size-footer-slack-input: 45px;
 $size-footer-slack-button: 45px;
-$size-footer-slack-band-right-distance: 30px;
-$size-footer-slack-band-bottom-distance: -10px;
 $max-wdith-footer-sitemap-mobile: 285px;
 $height-footer-mobile-buttons: 45px;
 $padding-horizontal-footer-mobile-buttons: 10px;
@@ -343,7 +339,6 @@ $padding-top-home-hero-mobile: 23px + $height-topbar-mobile;
 //..
 $padding-slack-form: 0;
 $margin-bottom-slack-form-input: 15px;
-$margin-bottom-slack-form-submit-button: 15px;
 $margin-bottom-slack-form-message: 15px;
 $margin-top-footer-slack: -($padding-section-vertical / 2);
 $padding-top-slack-form-header: 15px;
@@ -354,7 +349,7 @@ $margin-top-slack-form-logo: 22px;
 $margin-bottom-slack-form-title: 15px;
 $padding-lateral-input: 15px;
 $margin-right-slack-form-message-icon: 10px;
-$padding-bottom-slack-form-description: 60px;
+$padding-bottom-slack-form-description: 45px;
 //..
 $margin-hero-desc-vertical: 30px;
 $padding-hero-vertical: 90px;
@@ -438,7 +433,9 @@ $height-blog-cards-figure-height-mobile: 80px;
 $width-slack-form-horizontal-input-mobile: 315px;
 $width-slack-form-horizontal-button-mobile: 250px;
 $margin-top-slack-form-horizontal-elements: 20px;
-$size-slack-form-horizontal-message-spacing: -40px;
+$padding-top-slack-form-horizontal-message: 25px;
+$size-slack-form-horizontal-message-spacing: 40px;
+$size-slack-form-message-icon: 30px;
 //..
 $width-custom-page: 90%;
 $max-width-custom-page: 768px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,6 +1273,24 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
+commonmark-react-renderer@^4.2.4:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/commonmark-react-renderer/-/commonmark-react-renderer-4.3.3.tgz#9c4bca138bc83287bae792ccf133738be9cbc6fa"
+  dependencies:
+    in-publish "^2.0.0"
+    lodash.assign "^4.2.0"
+    lodash.isplainobject "^4.0.6"
+    pascalcase "^0.1.1"
+    xss-filters "^1.2.6"
+
+commonmark@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.24.0.tgz#b80de0182c546355643aa15db12bfb282368278f"
+  dependencies:
+    entities "~ 1.1.1"
+    mdurl "~ 1.0.1"
+    string.prototype.repeat "^0.2.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1792,7 +1810,7 @@ entities@1.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
 
-entities@~1.1.1:
+"entities@~ 1.1.1", entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
@@ -3424,6 +3442,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -3507,6 +3529,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
+
+"mdurl@~ 1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -4122,6 +4148,10 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -4543,7 +4573,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.10:
+prop-types@^15.5.1, prop-types@^15.5.10:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4648,6 +4678,15 @@ react-dom@^15.3.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-markdown@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-2.5.0.tgz#b1c61904fee5895886803bd9df7db23c3dc3a89e"
+  dependencies:
+    commonmark "^0.24.0"
+    commonmark-react-renderer "^4.2.4"
+    in-publish "^2.0.0"
+    prop-types "^15.5.1"
 
 react@^15.3.2:
   version "15.6.1"
@@ -5323,6 +5362,10 @@ string-width@^2.0.0, string-width@^2.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.repeat@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz#aba36de08dcee6a5a337d49b2ea1da1b28fc0ecf"
+
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -5899,6 +5942,10 @@ xdg-basedir@^3.0.0:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xss-filters@^1.2.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/xss-filters/-/xss-filters-1.2.7.tgz#59fa1de201f36f2f3470dcac5f58ccc2830b0a9a"
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Fixes https://github.com/src-d/backlog/issues/967

You will find below these lines screenshots of all defined states (`initial`, `success`), in desktop and mobile version, for the hero and footer slack forms.
The `onError` state screenshots are given by https://github.com/src-d/landing/pull/155#issuecomment-327240838 as requested by https://github.com/src-d/landing/pull/155#issuecomment-327022068 

## Hero form
### desktop
![landing-slack-desktop](https://user-images.githubusercontent.com/2437584/30036035-ee9fd012-91af-11e7-89a4-6401bb1c42ab.png)

### iPhone 6 Plus
(no change due to resolution)

## Footer form
### desktop
![image](https://user-images.githubusercontent.com/2437584/30035806-2e1b7ebe-91ae-11e7-82eb-2df3ebc2c276.png)
![image](https://user-images.githubusercontent.com/2437584/30035819-5ae61e86-91ae-11e7-964e-fba99f6ce3a2.png)
![image](https://user-images.githubusercontent.com/2437584/30035809-44846760-91ae-11e7-9fea-b1ae975817b1.png)


### iPhone 6 Plus
![landing-slack-iphone](https://user-images.githubusercontent.com/2437584/30036040-f2c951ea-91af-11e7-9c7d-2ed275302f9f.png)

/cc @marnovo 