### PR TITLE
Drone: change temporary values to production ones

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -72,7 +72,7 @@ pipeline:
     release: landing
     prefix: STG
     secrets: [ STG_API_SERVER, STG_KUBERNETES_TOKEN, SLACK_API_TOKEN ]
-    values: ingress.globalStaticIpName=landing-staging,image.landingSlackin.slackApiToken=$$SLACK_API_TOKEN,ingress.hosts={landing-staging.srcd.run,www.landing-staging.srcd.run},image.registry=quay.io/srcd,image.tag=${DRONE_COMMIT_SHA:0:7}
+    values: ingress.globalStaticIpName=landing-staging,image.landingSlackin.slackApiToken=$$SLACK_API_TOKEN,ingress.hosts={landing-staging.srcd.run,www.landing-staging.srcd.run},image.tag=${DRONE_COMMIT_SHA:0:7}
     tiller_ns: kube-system
     debug: true
     wait: true
@@ -147,7 +147,7 @@ pipeline:
     release: landing
     prefix: PROD
     secrets: [ PROD_API_SERVER, PROD_KUBERNETES_TOKEN, SLACK_API_TOKEN ]
-    values: ingress.globalStaticIpName=landing-production,image.landingSlackin.slackApiToken=$$SLACK_API_TOKEN,ingress.hosts={sourced.tech,www.sourced.tech},image.registry=quay.io/srcd,image.tag=${DRONE_TAG}
+    values: ingress.globalStaticIpName=landing-production,image.landingSlackin.slackApiToken=$$SLACK_API_TOKEN,ingress.hosts={sourced.tech,www.sourced.tech},image.tag=${DRONE_TAG}
     tiller_ns: kube-system
     debug: true
     wait: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -147,7 +147,7 @@ pipeline:
     release: landing
     prefix: PROD
     secrets: [ PROD_API_SERVER, PROD_KUBERNETES_TOKEN, SLACK_API_TOKEN ]
-    values: ingress.globalStaticIpName=landing-sourced-tech,image.landingSlackin.slackApiToken=$$SLACK_API_TOKEN,ingress.hosts={landingprod.sourced.tech,www.landingprod.sourced.tech},image.registry=quay.io/srcd,image.tag=${DRONE_TAG}
+    values: ingress.globalStaticIpName=landing-production,image.landingSlackin.slackApiToken=$$SLACK_API_TOKEN,ingress.hosts={sourced.tech,www.sourced.tech},image.registry=quay.io/srcd,image.tag=${DRONE_TAG}
     tiller_ns: kube-system
     debug: true
     wait: true


### PR DESCRIPTION
This is intended to be merged at the very moment of the migration to k8s.

(Actually it could be merged and nothing will happen if we don't push any tags. Also, nothing bad would really happen because DNS doesn't point to k8s)