### PR TITLE
Add a development rule to convert the landing into a documentation site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ COMPRESS := tar -zcf
 UNCOMPRESS := tar -zxf
 COPY := cp -R
 
+-include Makefile.development
+
 export CGO_ENABLED
 
 ## Lists all recipes

--- a/Makefile.development
+++ b/Makefile.development
@@ -1,0 +1,26 @@
+# Develop. vars
+doc_generator := ../docs
+src_assets := $(doc_generator)/assets
+project_yml_generator := $(doc_generator)/bin/config
+dev_output_project_yml := ./hugo/data/project.yml
+dev_src_raw := $(src_assets)/examples/hugo/content/raw
+dev_output_raw := ./hugo/content/raw
+dev_src_doc:=$(src_assets)/site/hugo/content
+dev_output_doc := ./hugo/content/documentation
+src_project_tpl := $(src_assets)/templates/project.yml.tpl
+src_categories_yml := ./hugo/data/categories.yml
+
+## Develop. Prepares the current Landing to look like a documentation site
+develop-documentation:
+	$(MKDIR) $(dev_output_doc)
+	$(COPY) $(dev_src_raw) $(dev_output_raw)
+	$(COPY) $(dev_src_doc)/*.md $(dev_output_doc)
+	HOST_NAME=landing.sourced.tech VERSION_NAME=v1 $(project_yml_generator) -tpl=$(src_project_tpl) -readme=./README.md -categories=$(src_categories_yml) > $(dev_output_project_yml)
+
+	PORT=8080 LANDING_URL=//localhost $(JS_PACKAGE_MANAGER) start;
+
+## Develop. Remove all stuff created to look like a documentation site
+develop-documentation-destroy:
+	$(REMOVE) $(dev_output_raw)
+	$(REMOVE) $(dev_output_doc)
+	$(REMOVE) $(dev_output_project_yml)

--- a/README.md
+++ b/README.md
@@ -37,18 +37,32 @@ Development and running the landing locally
 You need to satisfy all [project requirements](#requirements), and then to run:
 
 ```
-LANDING_URL=//localhost PORT=8181 make serve
+LANDING_URL=//localhost PORT=8080 make serve
 ```
-It runs everything you need to get the site working at [http://localhost:8181](http://localhost:8181)
+It runs everything you need to get the site working at [http://localhost:8080](http://localhost:8080)
 
 Alternatively, you can start hugo, the api-server and webpack in a "three window mode", just running:
 ```
-LANDING_URL=//localhost PORT=8181 yarn start
+LANDING_URL=//localhost PORT=8080 yarn start
 ```
 With this command, each window runs a command, that can be also ran by you in case you need to control the output of each command or in any other special case:
 * `yarn run webpack-watcher` To start webpack watcher, that will rebuild the assets when you change its sources
 * `make hugo-server` To serve the landing locally using hugo server
-* `yarn run api-run` To start the landing API at [http://localhost:8181](http://localhost:8181)
+* `yarn run api-run` To start the landing API at [http://localhost:8080](http://localhost:8080)
+
+## Preview the documentation site
+
+It can be seen the landing "as it would be a documentation site". To do so, it is needed to run:
+```
+make develop-documentation
+```
+And then, go to [http://localhost:8080](http://localhost:8080)
+
+To rollback the changes, and see the landing as usual, just run:
+```
+make develop-documentation-destroy
+```
+
 
 Configuration
 ===

--- a/hugo/data/categories.yml
+++ b/hugo/data/categories.yml
@@ -188,3 +188,20 @@ categories:
             - go
             - python
         # further demos are either legacy or WIP
+
+# ########## demos ##########
+
+    others:
+      name: others
+      colors: {left: "#888088", right: "#BBBBBB"}
+      desc: random and unrelared projects
+      projects:
+        - name: landing
+          hostname: landing.sourced.tech
+          url: https://github.com/src-d/landing
+          desc: landing of source{d}
+          repository: src-d/landing
+          languages:
+            - js
+            - html
+            - css


### PR DESCRIPTION
```
make develop-documentation
```
Development command that lets you see the landing as it would be a documentation site.
(see [README.md](https://github.com/src-d/landing/pull/167/files#diff-04c6e90faac2675aa89e2176d2eec7d8R53))