### PR TITLE
Change docsrv links by the github repo link

### DIFF
--- a/hugo/data/categories.yml
+++ b/hugo/data/categories.yml
@@ -36,7 +36,7 @@ categories:
       projects:
         - name: engine
           hostname: spark-api.sourced.tech
-          url: https://spark-api.sourced.tech
+          url: https://github.com/src-d/spark-api
           desc: the source{d} engine API combines data retrieval and language analysis tools for scalable pipelines that process any number of Git repositories for source code analysis
           repository: src-d/spark-api
           minVersion: v0.0.6
@@ -47,7 +47,7 @@ categories:
           logosmall:
         - name: go-git
           hostname: go-git.sourced.tech
-          url: https://go-git.sourced.tech
+          url: https://github.com/src-d/go-git
           desc: go-git is a highly extensible Git implementation in pure Go language
           repository: src-d/go-git
           minVersion: v4.0.0
@@ -71,7 +71,7 @@ categories:
             - go
         - name: śiva
           hostname: go-siva.sourced.tech
-          url: https://go-siva.sourced.tech
+          url: https://github.com/src-d/go-siva
           desc: śiva is an archiving format similar to TAR/ZIP, focused on allowing constant-time random file access, seekable access to contained files and concatenable files
           repository: src-d/go-siva
           minVersion: v1.1.2
@@ -92,14 +92,13 @@ categories:
           logo: projects/bblfsh
         - name: enry
           hostname: enry.sourced.tech
-          url: https://enry.sourced.tech
+          url: https://github.com/src-d/enry
           desc: enry is a faster source code file programming language detector based on github/linguist and toolbox that ignores binary or vendored files
           repository: src-d/enry
           minVersion: v1.5.1
           languages:
             - go
         - name: babelfish tools
-          hostname: enry.sourced.tech
           url: https://github.com/bblfsh/tools
           desc: babelfish tools are easy-to-use command line tools for simple code analysis, such as tokenizer, cyclomatic complexity, npath complexity, patch
           repository: bblfsh/tools

--- a/hugo/data/categories.yml
+++ b/hugo/data/categories.yml
@@ -135,7 +135,7 @@ categories:
             - python
             - cpp
         - name: minhashcuda
-          url: https://github.com/src-d/minshashcuda
+          url: https://github.com/src-d/minhashcuda
           desc: minhashcuda is a large-scale weighted MinHash implementation optimized for low memory and high speed by running on multiple NVIDIA GPUs (CUDA)
           repository: src-d/minhashcuda
           minVersion: 1.1.1

--- a/hugo/data/home/examples.yml
+++ b/hugo/data/home/examples.yml
@@ -4,4 +4,4 @@ examples:
     desc: The source{d} engine is a unified, scalable code analysis pipeline running on Apache Spark™ available through a friendly and flexible API; It is a single entry point to all the source{d} tools. <br /><br />It crawls, retrieves, stores, accesses, identifies languages and filters a single or all of the world’s public git repositories, generating from the source code a dataset of universal ASTs ready to be analysed or input into machine learning tools & models.
     code: engine-api.py
     language: python
-    link: https://spark-api.sourced.tech
+    link: https://github.com/src-d/spark-api


### PR DESCRIPTION
According to https://github.com/src-d/minutes/pull/58, the first public release will have no links pointing to docsrv.