### PR TITLE
Remove text transform from home hero title

### DIFF
--- a/src/sass/pages/home.scss
+++ b/src/sass/pages/home.scss
@@ -25,6 +25,7 @@
 
         h1 {
             @include title-big;
+            text-transform: none;
         }
 
         p {


### PR DESCRIPTION
as @marnovo requested by slack...
![image](https://user-images.githubusercontent.com/2437584/31575995-b1ddf2d2-b0f2-11e7-875a-349d1b668011.png)
