### PR TITLE
remove http->https redirection

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -3,11 +3,6 @@
     log stdout
     gzip
 
-    redir 301 {
-        if {>X-Forwarded-Proto} is http
-        /  https://{host}{uri}
-    }
-
     ext .html
     errors stdout {
         404 404.html


### PR DESCRIPTION
To avoid downtime while we migrate to k8s deployment

We will put it back after https certificates are in place