### PR TITLE
Apply graceful degradation for circles team on Safari

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -170,6 +170,13 @@ function setupTestimonials() {
   children.slice(0, 2).forEach(c => testimonials.appendChild(c));
 }
 
+function detectSafari() {
+  const detector = name => navigator.userAgent.search(name);
+  if (detector('Safari') >= 0 && detector('Chrome') < 0) {
+    document.body.classList.add('safari');
+  }
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   setupStickyHeader();
   setupMenu();
@@ -184,4 +191,5 @@ window.addEventListener('DOMContentLoaded', () => {
   });
   setupSmoothScroll();
   setupLinkTracking();
+  detectSafari();
 });

--- a/src/sass/components/circle-list.scss
+++ b/src/sass/components/circle-list.scss
@@ -122,3 +122,24 @@
         margin-left: 0 !important;
     }
 }
+
+/* Issue https://github.com/src-d/landing/issues/180 */
+body.safari {
+    .person-circle__background,
+    .person-circle__border,
+    #circleView {
+        display: none;
+    }
+
+    &.team-page .circle-list address {
+        svg {
+            background: white;
+            border-radius: 50%;
+        }
+
+        span[class*='linkedin'] svg {
+            padding: 3px;
+            border-radius: 0;
+        }
+    }
+}


### PR DESCRIPTION
quick fix for https://github.com/src-d/landing/issues/180

*graceful degradation* for Safari users **only**

![image](https://user-images.githubusercontent.com/2437584/31646820-7ab7191e-b304-11e7-93a0-7b9e9ee0bb84.png)

Already available at staging http://landing-staging.srcd.run/team/