### PR TITLE
Adds santiago to Team page

### DIFF
--- a/hugo/layouts/company/single.html
+++ b/hugo/layouts/company/single.html
@@ -224,6 +224,16 @@
             </div>
             <div class="col-sm-6 col-lg-3 mb-4">
                 <div class="card white">
+                    <img class="w-100" src="assets/img/team/santiago.png" alt="">
+                    <div class="card-body">
+                        <a href="https://github.com/smola" class="ic icon-git text-light"></a>
+                        <p class="card-intro text-medium mt-3 mb-2">Head of Architecture</p>
+                        <h4 class="text-dark title-line line-yellow">Santiago Mola</h4>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-lg-3 mb-4">
+                <div class="card white">
                     <img class="w-100" src="assets/img/team/alex.png" alt="">
                     <div class="card-body">
                         <a href="https://github.com/bzz" class="ic icon-git text-light"></a>


### PR DESCRIPTION
In this first version we have not yet integrated the team YAML for content, we have to edit it directly in the /hugo/layouts/company/single.html template. This sort things out.