### PR TITLE
Fix external links with the same path

### DIFF
--- a/static/js-load/script.js
+++ b/static/js-load/script.js
@@ -54,7 +54,9 @@ $('body').on('click', 'a', function (e) {
     const url = new URL(this.href);
     const urlPath = url.pathname.replace(/\/$/, "");
     const currentPath = window.location.pathname.replace(/\/$/, "");
-    if (urlPath !== currentPath || url.hash === '') {
+    if (url.host !== window.location.host ||
+        urlPath !== currentPath ||
+        url.hash === '') {
         return true;
     }
     


### PR DESCRIPTION
It was failing when the external url had the same path as the current page, e.g. `https://sourced.tech/engine/` and `https://docs.sourced.tech/engine#quickstart`