### PR TITLE
Remove mention to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This repository contains the sources of the [source{d}](https://sourced.tech) Landing and its API.
 
-The Landing repository is also used as a [boilerplate for our documentation sites](https://github.com/src-d/docs).
-
 ![Screenshot](.github/screenshot.png?raw=true)
 
 


### PR DESCRIPTION
Landing won't be used as a docs boilerplate