### PR TITLE
Add team pictures into robots.txt

### DIFF
--- a/hugo/layouts/robots.txt
+++ b/hugo/layouts/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /img/people/*
+Disallow: /img/team/*


### PR DESCRIPTION
depends on #316

The old path for team images was wrong

The changes are done only in the last commit
- 9703f72 Add team pictures into robots.txt  

It can be tested in staging/prod, using https://technicalseo.com/seo-tools/robots-txt/, checking the images that were indexed in each case:
- :ok: https://landing-staging.srcd.run/company/ &rarr; new `robots.txt`
- :no_entry_sign:  https://sourced.tech/company/ &rarr; old `robots.txt`
