### PR TITLE
Fix the title  of the blog posts in latest updates

### DIFF
--- a/hugo/layouts/mustache-tpls/posts.tpl
+++ b/hugo/layouts/mustache-tpls/posts.tpl
@@ -20,7 +20,7 @@
                     )"></div>
                 <div class="card-body">
                     <h5 class="card-title text-dark">
-                        [[#ellipsis35]][[description]][[/ellipsis35]]
+                        [[#ellipsis35]][[title]][[/ellipsis35]]
                     </h5>
                     <p class="card-text">[[#ellipsis70]][[description]][[/ellipsis70]]</p>
                     <span class="author">[[author]]</span>


### PR DESCRIPTION
The post description is being shown twice in 2nd and 3rd blog post card.

before:
![image](https://user-images.githubusercontent.com/2437584/48500419-1baf7c00-e83b-11e8-8cb7-2d6966c6cf3e.png)

after:
![image](https://user-images.githubusercontent.com/2437584/48500432-236f2080-e83b-11e8-9b18-4f4b0ea3264c.png)
