### PR TITLE
Make the announcements section easy to be configured

### DIFF
--- a/hugo.config.yaml
+++ b/hugo.config.yaml
@@ -46,3 +46,7 @@ params:
         twitter: "sourcedtech"
         github: "src-d"
         linkedin: "sourced"
+    # fixed web announcment; if one of its properties is empty, it won't be displayed.
+    announcement:
+        title: "Watch a 5 minutes video to understand how the engine works"
+        url: "https://medium.com/sourcedtech/source-d-engine-in-5-minutes-6b3b19789594"

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -47,13 +47,16 @@
 </header>
 
 <section class="news pt-3 pb-3">
-    <div class="container">
-        <h4 class="text-dark m-0"><span class="badge badge-warning">New</span><a href="https://blog.sourced.tech/post/announcing-pga/" style="    color: #000;
-            text-decoration: none;
-            font-weight: 500;
-            font-size: 21px;
-            padding: 0px 0 0 13px;">Announcing Public Git Archive!</a></h4>
-    </div>
+    {{ if and (default false .Site.Params.announcement.title) (default false .Site.Params.announcement.url) }}
+        <div class="container">
+            <h4 class="text-dark m-0">
+                <span class="badge badge-warning">New</span>
+                <a class="badge-text" href="{{ .Site.Params.announcement.url }}">
+                    {{ .Site.Params.announcement.title }}
+                </a>
+            </h4>
+        </div>
+    {{ end }}
 </section>
 
 <section id="why" class="why pt-5 pb-0 pb-m-5">

--- a/src/sass/partials/_layout.scss
+++ b/src/sass/partials/_layout.scss
@@ -247,6 +247,18 @@
   }
 }
 
+
+// Home - Announcement
+
+section.news .badge-text {
+    color: #000;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 21px;
+    padding: 0px 0 0 13px;
+}
+
+
 // Home - Why source{d}
 
 section.why {

--- a/src/sass/partials/_layout.scss
+++ b/src/sass/partials/_layout.scss
@@ -255,7 +255,7 @@ section.news .badge-text {
     text-decoration: none;
     font-weight: 500;
     font-size: 21px;
-    padding: 0px 0 0 13px;
+    padding: 0 0 0 13px;
 }
 
 


### PR DESCRIPTION
fix #325

The landing main announcement can be changed modifying `hugo.config.yaml::announcement` ([here](https://github.com/src-d/landing/compare/master...dpordomingo:news-section#diff-445c7687581b0a438b12802832e4bcc6R50))

If no `title` or `url` is provided for the `announcement`, it wont be shown at the landing (leaving an empty white row in that place)

Here is a screenshot with the purpose made by @campoy at https://github.com/src-d/landing/issues/325#issue-380868161

![image](https://user-images.githubusercontent.com/2437584/48642571-987a5b80-e9dd-11e8-865c-136bc785f068.png)

