### PR TITLE
Added affinity rules to landing

### DIFF
--- a/.helm-production.yml
+++ b/.helm-production.yml
@@ -5,3 +5,14 @@ ingress:
     - www.sourced.tech
 nodeSelector:
   cloud.google.com/gke-nodepool: default-pool
+affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+         matchExpressions:
+          - key: app
+            operator: In
+            values:
+         #if the chart name is changed or a nameOverride is used, this value has to be changed to the new name.
+                - landing
+        topologyKey: kubernetes.io/hostname

--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -5,3 +5,14 @@ ingress:
     - www.landing-staging.srcd.run
 nodeSelector:
   cloud.google.com/gke-nodepool: default-pool
+affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+         matchExpressions:
+          - key: app
+            operator: In
+            values:
+         #if the chart name is changed or a nameOverride is used, this value has to be changed to the new name.
+                - landing
+        topologyKey: kubernetes.io/hostname

--- a/helm-charts/landing/Chart.yaml
+++ b/helm-charts/landing/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: landing
-version: 0.1.1
+version: 0.2.0

--- a/helm-charts/landing/templates/deployment.yaml
+++ b/helm-charts/landing/templates/deployment.yaml
@@ -55,3 +55,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end}}


### PR DESCRIPTION
Antiaffinity rules to avoid two or more pods running on the same node.

Signed-off-by: David Riosalido <driosalido@sourced.tech>