### PR TITLE
New layout for the advantages on the product page

### DIFF
--- a/hugo/layouts/engine/single.html
+++ b/hugo/layouts/engine/single.html
@@ -19,7 +19,7 @@
             <h2 class="text-dark mb-5">source{d} Engine</h2>
         </header>
         <div class="row text-dark mb-5">
-            <div class="col-sm-10 offset-md-1">
+            <div class="col-sm-12">
                 <p class="text-large mb-5">Engineering managers and maintainers of large code bases are starting to realize the potential of Code as Data or how source code can be treated as an analyzable dataset proving valuable information. Think Business Intelligence and processes optimization based on the source code engineers write, rather than adjacent metrics.</p>
                 <h3 class="title-line line-green">Code as Data Challenges</h3>
                 <ul class="small-list mb-5">
@@ -34,39 +34,55 @@
             </div>
         </div>
         <div class="row text-dark mb-5">
-                <div class="col-md-6 col-lg-3 text-center">
+                <div class="col-md-6">
                     <div class="card bg-transparent">
-                        <div class="card-body">
-                            <img class="mb-3" src="img/icons/code-retrieval.svg" height="140" width="140" alt="">
-                            <h4 class="title-line line-green">Code Retrieval</h4>
-                            <p>Retrieve and store the code history of your organization (including your open-source repositories) as a dataset.</p>
+                        <div class="card-body row">
+                            <div class="col-sm-3 col-md-12 col-lg-4">
+                                <img class="mb-3 img-fluid mw-150" src="img/icons/code-retrieval.svg" alt="">
+                            </div>
+                            <div class="col-sm-9 col-md-12 col-lg-8">
+                                <h4 class="title-line line-green">Code Retrieval</h4>
+                                <p>Retrieve and store the code history of your organization (including your open-source repositories) as a dataset.</p>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div class="col-md-6 col-lg-3 text-center">
+                <div class="col-md-6">
                     <div class="card bg-transparent">
-                        <div class="card-body">
-                            <img class="mb-3" src="img/icons/language-agnostic-code-analysis.svg" height="140" width="140" alt="">
-                            <h4 class="title-line line-green">Language Agnostic Code Analysis</h4>
-                            <p>Automatically identify languages, parse source code, and extract the pieces that matter in a completely language-agnostic way.</p>
+                        <div class="card-body row">
+                            <div class="col-sm-3 col-md-12 col-lg-4">
+                                <img class="mb-3 img-fluid mw-150" src="img/icons/language-agnostic-code-analysis.svg" alt="">
+                            </div>
+                            <div class="col-sm-9 col-md-12 col-lg-8">
+                                <h4 class="title-line line-green">Language Agnostic Code Analysis</h4>
+                                <p>Automatically identify languages, parse source code, and extract the pieces that matter in a completely language-agnostic way.</p>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div class="col-md-6 col-lg-3 text-center">
+                <div class="col-md-6">
                     <div class="card bg-transparent">
-                        <div class="card-body">
-                            <img class="mb-3" src="img/icons/history-analysis.svg" height="140" width="140" alt="">
-                            <h4 class="title-line line-green">History Analysis</h4>
-                            <p>Extract information from the evolution, commits, and metadata of your codebase and  generate detailed reports and insights.</p>
+                        <div class="card-body row">
+                            <div class="col-sm-3 col-md-12 col-lg-4">
+                                <img class="mb-3 img-fluid mw-150" src="img/icons/history-analysis.svg" alt="">
+                            </div>
+                            <div class="col-sm-9 col-md-12 col-lg-8">
+                                <h4 class="title-line line-green">History Analysis</h4>
+                                <p>Extract information from the evolution, commits, and metadata of your codebase and  generate detailed reports and insights.</p>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div class="col-md-6 col-lg-3 text-center">
+                <div class="col-md-6">
                     <div class="card bg-transparent">
-                        <div class="card-body">
-                            <img class="mb-3" src="img/icons/familiar-apis.svg" height="140" width="140" alt="">
-                            <h4 class="title-line line-green">Familiar APIs</h4>
-                            <p>Analyze your code through powerful friendly APIs, such as SQL, gRPC, REST, and various client libraries.</p>
+                        <div class="card-body row">
+                            <div class="col-sm-3 col-md-12 col-lg-4">
+                                <img class="mb-3 img-fluid mw-150" src="img/icons/familiar-apis.svg" alt="">
+                            </div>
+                            <div class="col-sm-9 col-md-12 col-lg-8">
+                                <h4 class="title-line line-green">Familiar APIs</h4>
+                                <p>Analyze your code through powerful friendly APIs, such as SQL, gRPC, REST, and various client libraries.</p>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/sass/partials/_main.scss
+++ b/src/sass/partials/_main.scss
@@ -15,6 +15,12 @@ a {
     }
 }
 
+// Helpers
+
+.mw-150 {
+    max-width: 150px;
+}
+
 // Buttons
 
 .btn {


### PR DESCRIPTION
Based on the document [Landing Quick fixes & improvements](https://docs.google.com/document/d/1rCasMWwPL-VosmWCd98cXdZsQnBVbVjsuYdQvCbjO9c/edit#), this update changes the Product Advantages sub-section to a new layout with the images on the left and full width for the content.

There is [a design pattern library related PR here](https://github.com/src-d/design/pull/16).

Before:

![image](https://user-images.githubusercontent.com/14981468/51492850-7ae9b980-1db3-11e9-8cbe-0ba12b8c822a.png)

After:

![image](https://user-images.githubusercontent.com/14981468/51492864-8806a880-1db3-11e9-8879-5f3eadaae694.png)

Signed-off-by: znegrin <zurinegrin@gmail.com>