### PR TITLE
#1343 Including video on the Engine product page

### DIFF
--- a/hugo/layouts/engine/single.html
+++ b/hugo/layouts/engine/single.html
@@ -72,6 +72,14 @@
                 </div>
             </div>
         <div class="row">
+            <div class="col-sm-12 mb-5">
+                <h3 class="title-line line-green">source{d} Engine in five minutes</h3>
+                <div class="embed-responsive embed-responsive-16by9">
+                    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/YLxvK027Npo" allowfullscreen></iframe>
+                </div>
+            </div>
+        </div>
+        <div class="row">
             <div class="col-lg-9 mb-3 mb-lg-0 text-center text-lg-left">
                 <div class="card text-white green">
                     <div class="card-body p-5">

--- a/hugo/layouts/engine/single.html
+++ b/hugo/layouts/engine/single.html
@@ -73,9 +73,13 @@
             </div>
         <div class="row">
             <div class="col-sm-12 mb-5">
-                <h3 class="title-line line-green">source{d} Engine in five minutes</h3>
-                <div class="embed-responsive embed-responsive-16by9">
-                    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/YLxvK027Npo" allowfullscreen></iframe>
+                <h3 class="title-line text-dark line-green">source{d} Engine in five minutes</h3>
+                <div class="card white shadow-lg">
+                    <div class="card-body p-3">
+                        <div class="embed-responsive embed-responsive-16by9">
+                            <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/YLxvK027Npo" allowfullscreen></iframe>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR is related to the backlog issue [#1343](https://github.com/src-d/backlog/issues/1343).

More information available on the document: [Landing Quick fixes & improvements](https://docs.google.com/document/d/1rCasMWwPL-VosmWCd98cXdZsQnBVbVjsuYdQvCbjO9c/edit#)

Added a responsive video and title on the Engine page as requested. Notice that the actual thumbnail differs from the desired one, but it should be changed on the YouTube video itself.

![image](https://user-images.githubusercontent.com/14981468/51494208-2268eb00-1db8-11e9-9d5b-e78e552de390.png)


Signed-off-by: znegrin <zurinegrin@gmail.com>