### PR TITLE
Update to go 1.12

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ deploy_staging_tag_name: &deploy_staging_tag_name
   tag: 'commit-${DRONE_COMMIT_SHA:0:7}'
 
 build: &build
-  image: golang:1.8
+  image: golang:1.12
   debug: true
   commands:
     - apt-get update


### PR DESCRIPTION
Use newer Travis base image, in order to avoid [issue in drone](https://drone.srcd.host/src-d/landing/479) for missing `jessie-updates`
```
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages
  404  Not Found [IP: 151.101.120.204 80]
```
