### PR TITLE
HACK. prevent scroll in some links

### DIFF
--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -40,16 +40,16 @@
         <div class="row">
             <ul class="nav nav-tabs eng-tabs text-center mb-3 mb-md-0" id="engTabs" role="tablist">
                 <li class="nav-item eng-tab-1 col-sm-12 col-md-3">
-                    <a class="nav-link h6 pb-3 h-100 active" id="engTab01-tab" data-toggle="tab" href="#engTab01" role="tab" aria-controls="engTab01" aria-selected="true">IT Modernization & Application Portfolio Management</a>
+                    <a data-scroll="no" class="nav-link h6 pb-3 h-100 active" id="engTab01-tab" data-toggle="tab" href="#engTab01" role="tab" aria-controls="engTab01" aria-selected="true">IT Modernization & Application Portfolio Management</a>
                 </li>
                 <li class="nav-item eng-tab-2 col-sm-12 col-md-3">
-                    <a class="nav-link h6 pb-3 h-100" id="engTab02-tab" data-toggle="tab" href="#engTab02" role="tab" aria-controls="engTab02" aria-selected="false">DevOps & Cloud Native adoption</a>
+                    <a data-scroll="no" class="nav-link h6 pb-3 h-100" id="engTab02-tab" data-toggle="tab" href="#engTab02" role="tab" aria-controls="engTab02" aria-selected="false">DevOps & Cloud Native adoption</a>
                 </li>
                 <li class="nav-item eng-tab-3 col-sm-12 col-md-3">
-                    <a class="nav-link h6 pb-3 h-100" id="engTab03-tab" data-toggle="tab" href="#engTab03" role="tab" aria-controls="engTab03" aria-selected="false">Engineering effectiveness & efficiency</a>
+                    <a data-scroll="no" class="nav-link h6 pb-3 h-100" id="engTab03-tab" data-toggle="tab" href="#engTab03" role="tab" aria-controls="engTab03" aria-selected="false">Engineering effectiveness & efficiency</a>
                 </li>
                 <li class="nav-item eng-tab-4 col-sm-12 col-md-3">
-                    <a class="nav-link h6 pb-3 h-100" id="engTab04-tab" data-toggle="tab" href="#engTab04" role="tab" aria-controls="engTab04" aria-selected="false">Talent Assessment and Management</a>
+                    <a data-scroll="no" class="nav-link h6 pb-3 h-100" id="engTab04-tab" data-toggle="tab" href="#engTab04" role="tab" aria-controls="engTab04" aria-selected="false">Talent Assessment and Management</a>
                 </li>
             </ul>
         </div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -96,6 +96,10 @@ $(function(){
 const headerHeight = $('nav.navbar').height();
 
 $('body').on('click', 'a', function (e) {
+    if (this.getAttribute('data-scroll') === 'no') {
+      return true;
+    }
+
     const url = new URL(this.href);
     const urlPath = url.pathname.replace(/\/$/, "");
     const currentPath = window.location.pathname.replace(/\/$/, "");


### PR DESCRIPTION
caused by https://github.com/src-d/landing/issues/391

This quick and dirty hack is considered as a hotfix for #391
When applied, the 'scrollTo' behavior will be disabled for elements having a 'data-scroll' attribute set as 'no'

This PR should not be considered as a final solution for https://github.com/src-d/landing/issues/391, but an ugly hotfix.