### PR TITLE
Adding Legal page to the landing

### DIFF
--- a/hugo/content/legal.md
+++ b/hugo/content/legal.md
@@ -1,0 +1,7 @@
+---
+type: legal
+section: legal
+url: legal
+title: source{d} Legal terms
+socialDescription: source{d} Legal terms.
+---

--- a/hugo/layouts/legal/single.html
+++ b/hugo/layouts/legal/single.html
@@ -1,0 +1,139 @@
+{{ $projects := $.Site.Data.projects }}
+
+{{ $headCtx := dict "ctx" . }}
+{{ partial "head.html" $headCtx }}
+
+<body class="legal">
+{{ partial "header.html" }}
+<div class="text-left pb-5">
+    <br><br>
+    <h1 class="title text-left p-0 mt-5 mb-4">source{d} Legal terms</h1>
+</div>
+</div>
+</header>
+
+<section id="privacy" class="text-dark pb-5">
+    <div class="container pt-5">
+        <div class="row">
+            <div class="col-12">
+                <h3 class="title-line line-yellow">Privacy</h3>
+                <p>This Website is the property of SOURCED TECHNOLOGIES SL a Spanish company registered in Claudio Coello 16, 2, Madrid, Spain and with tax registration number B86776838.</p>
+                <p>The personal data that you have submitted through <strong>sourced.tech</strong> will be processed by SOURCED TECHNOLOGIES SL for the purposes of answering your email and/or joining you to our community, and during the term strictly necessary to these intended purposes.</p>
+                <p>The legal bases for the processing of the data are your consent and the legitimate interests pursued by <strong>sourced.tech</strong> to answer your email and/or to join you to our community.</p>
+                <p>SOURCED TECHNOLOGIES SL will process adequate, relevant, accurate and updated personal data and limited to what is necessary, and will do it in a lawfully, fairly and in a the transparent manner by adopting every reasonable step, measures, and process to ensure a level of security appropriate to the risk.</p>
+                <p>You are responsible for the veracity of the data protection submitted and, except you expressly notice a change in your personal data, SOURCED TECHNOLOGIES SL will consider your personal data accurate.</p>
+                <p>You can exercise the right to request from SOURCED TECHNOLOGIES SL, by contacting hello@<strong>sourced.tech</strong>, access to and rectification or erasure of personal data or restriction of processing concerning personal data and to object to the processing as well as the right to data portability. Additionally, you have the right to lodge a complaint with a supervisory authority. By sending an email, you are accepting this Privacy Notice.</p>
+                <p>Last update: 22/05/2018</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section id="terms" class="text-dark pb-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h3 class="title-line line-yellow">Terms of Service</h3>
+                <div class="mb-5">
+                    <h5>1. - Owner of this website.</h5>
+                    <p>This Website is the property of SOURCED TECHNOLOGIES SL a Spanish company registered in Claudio Coello 16, 2, Madrid, Spain and with tax registration number B86776838.</p>
+                </div>
+                <div class="mb-5">
+                    <h5>2. - General issues.</h5>
+                    <p>The Access to the Website <strong><strong>sourced.tech</strong></strong> is subject to having read these User Terms and the other policies and notices contained in this Website.</p>
+                    <p>For the purposes of this Website, a User is understood as any person entering the site <strong><strong>sourced.tech</strong></strong>.</p>
+                    <p>The access and use of this Website by the User implies the commitment and obligation to make appropriate use of this Website, subject to the present User Terms and current legislation, either national or international, as well as to the principles of good faith, morals and the public order, with the commitment to diligently observe any and all additional instructions in relation to such use and access as may be given from SOURCED TECHNOLOGIES SL.</p>
+                    <p>If the User does not agree with these User Terms shall be to terminate the access and use of the Website <strong><strong>sourced.tech</strong></strong>.</p>
+                    <p>The access to the Website <strong><strong>sourced.tech</strong></strong> is free of charges and its visualization does not require any previous subscription or registration.</p>
+                    <p>Any use of the Website <strong>sourced.tech</strong>, not subject to the content of these User Terms, is expressly prohibited and SOURCED TECHNOLOGIES SL reserves its rights to take all necessary legal action against the User without further notice which would have resulted from the no respect of these User Terms.</p>
+                </div>
+                <div class="mb-5">
+                    <h5>3. - Rights and obligations of <strong>sourced.tech</strong>.</h5>
+                    <p>The use that the User may do with the information provided by <strong>sourced.tech</strong> is at the exclusive User's own risk.</p>
+                    <p>SOURCED TECHNOLOGIES SL does not guarantee the accuracy or timeless of the information provided for the purposes the User and/or any other persons may make of it.</p>
+                    <p>SOURCED TECHNOLOGIES SL will be able to change unilaterally, at any time considered appropriate, the configuration and/or content of this Website <strong>sourced.tech</strong> and its User Terms, trying to inform the User about this change, whenever the circumstances allow it through the publication on the Website <strong>sourced.tech</strong>.</p>
+                    <p>In the event of any maintenance, repair, and updating or improvement operations, SOURCED TECHNOLOGIES SL may suspend temporally, at any moment and without the need of notice previous, the access to <strong>sourced.tech</strong>, although it shall try to inform the User whenever the circumstances allow it.</p>
+                </div>
+                <div class="mb-5">
+                    <h5>4. - Rights and obligations of the User.</h5>
+                    <p>At any time, the User has to make lawful use of the Website <strong>sourced.tech</strong> and subject to the present User Terms and current legislation, either national or international and always the intellectual property right of SOURCED TECHNOLOGIES SL and/or third parties.</p>
+                    <p>The User may not, under any circumstances, to perform any actions which may cause damage or alterations to the contents or hinder the correct operation of the Website <strong>sourced.tech</strong>, and may not cause technical problems of any sort whatsoever, transferring elements that might contain computer virus or damage, interfere or intercept the present website as a whole or partially.</p>
+                    <p>The User is the sole party responsible for the veracity of the information and data that he supplies, in the case, the User supplies false, incorrect and/or non-update information, SOURCED TECHNOLOGIES SL reserves its rights to prohibit to the User the access to the Website <strong>sourced.tech</strong>, and, additionally, the possibility to not be able to respond to its requests and correspondences.</p>
+                    <p>SOURCED TECHNOLOGIES SL reserve its rights to take all necessary legal action against the User without further notice for uses against the current national or international legislation and/or causing any type of harm or damage to SOURCED TECHNOLOGIES SL and/or its partners and/or third parties. </p>
+                </div>
+                <div class="mb-5">
+                    <h5>5. - Guarantees and responsibility for the operation of the Website <strong>sourced.tech</strong>.</h5>
+                    <p>SOURCED TECHNOLOGIES SL shall not be liable for damages of any kind that may result from the availability and technical continuity of the Website. In any case, SOURCED TECHNOLOGIES SL shall take all necessary measures to restore services in the event of technical failure.</p>
+                    <p>SOURCED TECHNOLOGIES SL has adopted every reasonable step, measures and process to ensure appropriate security of the personal data which are adequate, relevant, accurate and updated personal data and limited to what is necessary.</p>
+                    <p>SOURCED TECHNOLOGIES SL does not control or guarantee the presence or absence of virus or other elements in the content of the Website <strong>sourced.tech</strong> which can produce alterations in the computer system (software or hardware) of the User and/or in the electronic documents and files stored in his systems.</p>
+                    <p>SOURCED TECHNOLOGIES SL disclaims all liability for damages of any kind due to the presence of viruses in the content of the Website <strong>sourced.tech</strong> which could cause alterations to the computer system, electronic documents, files, etc.</p>
+                    <p>SOURCED TECHNOLOGIES SL does not have the obligation to control and does not control the use of the Website <strong>sourced.tech</strong> by users.</p>
+                    <p>The User accepts that <strong>sourced.tech</strong> has been created and developed in good faith by SOURCED TECHNOLOGIES SL with information coming from internal and external sources this is offered to the User in its current state and may contain errors or inaccuracies.</p>
+                    <p>For this reason, SOURCED TECHNOLOGIES SL is not responsible for the lack of the utility or false expectations that <strong>sourced.tech</strong> could be caused to the User during the access and navigation in <strong>sourced.tech</strong>.</p>
+                </div>
+                <div class="mb-5">
+                    <h5>6. - Intellectual Property.</h5>
+                    <p>SOURCED TECHNOLOGIES SL is the holder of all intellectual and industrial property rights of this Website. It is forbidden to copy in any way, reproduce, distribute, communicate publicly, transform and, in general, use in any way all or part of the contents (images, text, graphics, indexes, forms, etc.) contained on the Website <strong>sourced.tech</strong>, or in databases and software required for viewing or operation thereof, without the express prior written authorization of SOURCED TECHNOLOGIES SL.</p>
+                    <p>The User may not, under any circumstances, use or make commercial use of any of the contents (images, text, graphics, indexes, forms, etc.) of the Website <strong>sourced.tech</strong>, directly or indirectly, without the express prior written authorization of SOURCED TECHNOLOGIES SL. </p>
+                    <p>All trademarks and logos contained on the Website <strong>sourced.tech</strong> are the exclusive trademarks or the registered trademarks of SOURCED TECHNOLOGIES SL or have been used with the permission of their respective owners.</p>
+                    <p>The User may not, under any circumstances, use these trademarks and logos without the express prior written permission of SOURCED TECHNOLOGIES or their respective owners.</p>
+                    <p>SOURCED TECHNOLOGIES SL will pursue any infraction of its Intellectual Property Rights and reserves its rights to take all necessary legal action, including an action for damage.</p>
+                </div>
+                <div class="mb-5">
+                    <h5>7. - Link, hyperlink, framing or similar linkage.</h5>
+                    <p>The User may not, under any circumstances, insert on the Website <strong>sourced.tech</strong>, a link, hyperlink, framing or similar linkage redirecting to <strong>sourced.tech</strong>, without prior consent SOURCED TECHNOLOGIES SL.</p>
+                    <p>The link, hyperlink, framing or similar linkage included by SOURCED TECHNOLOGIES SL in <strong>sourced.tech</strong> are offered solely as informative references, without any type of valuation regarding the content, owners, services or goods offered from the link, hyperlink, framing or similar linkage.</p>
+                    <p>In any case, SOURCED TECHNOLOGIES SL will NOT be responsible for damages caused by the services of third parties.</p>
+                </div>
+                <div class="mb-5">
+                    <h5>8. - Applicable law and jurisdiction.</h5>
+                    <p>Current legislation shall determine the applicable law and the jurisdiction that will govern relations between SOURCED TECHNOLOGIES SL and the User. Nevertheless, for those cases in which the said legislation foresees the possibility of the parties being subject to a given applicable law and/or jurisdiction, SOURCED TECHNOLOGIES SL and the User expressly renounce any other jurisdiction that may correspond to them, and agree to be governed in any disputes or disagreements by the Courts and Tribunals of the city of Madrid, Spain.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section id="trademark" class="text-dark pb-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h3 class="title-line line-yellow">Trademark Guidelines</h3>
+                <p>The trademark source{d}™ is SOURCED TECHNOLOGIES SL intellectual property and is valuable asset to this company.</p>
+                <p>Trademark Overview: The trademark source{d}™ has ….. [description, minimum size, colors permitted, font family …].</p>
+                <p>You may use source{d}™ to refer to SOURCED TECHNOLOGIES SL software in print materials and other media, as long as you adhere to the following guidelines and do not use source{d}™ in a disparaging or inaccurate manner. In following these guidelines, you help us protect our valuable trademark rights.</p>
+                <ul class="small-list">
+                    <li>Use correct spelling. Always spell and capitalize the trademarks exactly as source{d}™</li>
+                    <li>Use appropriate markings. Always designate the trademark with the appropriate ™ or ® symbol in the text of print material or other media. For the trademark symbol, the superscript mode is preferred, but if it is not available, use parentheses: (TM) or (R).</li>
+                    <li>Use the trademark as an adjective. Always use the trademark as an adjective accompanied by an appropriate noun. Do not pluralize a trademark, make it possessive, or use it as a verb. For example, source{d}™ materials, source{d}™ software, source{d}™ methodology, others.</li>
+                    <li>Attribute ownership of source{d}™ to SOURCED TECHNOLOGIES SL. When referring to source{d}™ include a notice of trademark attribution where appropriate on all labeling, print collateral, or other media.</li>
+                    <li>Do not imply a relationship that does not exist. Your reference to source{d}™ must not imply an endorsement, sponsorship, association, or relationship with SOURCED TECHNOLOGIES SL when such endorsement, sponsorship, association, or relationship does not exist.</li>
+                </ul>
+                <p>Except for the limited right to use source{d}™ as expressly permitted under these guidelines, no other rights of any kind are granted hereunder, by implication or otherwise. If you have any questions regarding these guidelines, please submit your query to hello@sourced.com .</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section id="components" class="text-dark pb-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h3 class="title-line line-yellow">Components & licensing</h3>
+                <p>Our current approach has our technology stack fully open-source under permissive licenses such as <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</a> and
+                    <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GPL 3.0</a>. [1] </p>
+                <p>We have released a community edition of source{d} for single node deployments. We also have a an enterprise edition for multi-node deployments which allows distributed computing and storage over a vast amount of repositories with a large number of concurrent users. The enterprise edition also includes security and governance features as well as flexible infrastructure deployments and support services.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+{{ partial "footer.html" }}
+</body>
+</html>
+</title>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
This PR is related to this issue: https://github.com/src-d/backlog/issues/1404

I added the legal page. Notice that there seems to be some contents not completed on the Trademark section.

![image](https://user-images.githubusercontent.com/14981468/58324837-4bfa5780-7e28-11e9-892f-6437ad3d4a31.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>