### PR TITLE
SEO changes on the homepage

### DIFF
--- a/hugo.config.yaml
+++ b/hugo.config.yaml
@@ -35,7 +35,7 @@ taxonomies:
 
 params:
     author: source{d}
-    description: "source{d} provides the technology for large-scale code analysis and machine learning on code."
+    description: "Source{d} is the only end to end Engineering Observability platform to provide executives with actionable insights about their codebases, development processes, and teams. Source{d} not only helps enterprises improve their engineering effectiveness and efficiency but also their IT modernization, DevOps Adoption, and Engineering talent management efforts."
     defaultemail: "hello@sourced.tech"
     location: "San Francisco, Seattle, Madrid & Remote"
     favicon: "img/logos/favicon.png"

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -2,6 +2,6 @@
 type: index
 section: index
 url: /
-title: Machine Learning for Large Scale Code Analysis
+title: The Data Platform for your Software Development Life Cycle
 socialIsLargeImage: true
 ---


### PR DESCRIPTION
This PR adds some changes on the SEO for the homepage:

- Title changed to “The Data Platform for your Software Development Life Cycle”
- Description changed to: "Source{d} is the only end to end Engineering Observability platform to provide executives with actionable insights about their codebases, development processes, and teams. Source{d} not only helps enterprises improve their engineering effectiveness and efficiency but also their IT modernization, DevOps Adoption, and Engineering talent management efforts."

As requested on the issue #413 

Notice that I wasn't able to add the keywords as I wasn't sure of where to do so. Maybe @dpordomingo  can help me with that.

Thank you!