### PR TITLE
Capitalize "Edition" on the header and footer navigation

### DIFF
--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -9,8 +9,8 @@
             <div class="col-sm">
                 <ul>
                     <li><a class="footer-main" href="products/community-edition">Product</a></li>
-                    <li><a href="products/community-edition">source{d} Community edition</a></li>
-                    <li><a href="products/enterprise-edition">source{d} Enterprise edition</a></li>
+                    <li><a href="products/community-edition">source{d} Community Edition</a></li>
+                    <li><a href="products/enterprise-edition">source{d} Enterprise Edition</a></li>
                     <li><a href="get-started#engineers-tab">source{d} for Developers</a></li>
                     <li><a href="get-started#managers-tab">source{d} for Managers</a></li>
                     <li><a href="get-started#executives-tab">source{d} for Executives</a></li>

--- a/hugo/layouts/partials/header.html
+++ b/hugo/layouts/partials/header.html
@@ -19,8 +19,8 @@
                             Products
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkProd">
-                            <a class="dropdown-item" href="products/community-edition">source{d} Community edition</a>
-                            <a class="dropdown-item" href="products/enterprise-edition">source{d} Enterprise edition</a>
+                            <a class="dropdown-item" href="products/community-edition">source{d} Community Edition</a>
+                            <a class="dropdown-item" href="products/enterprise-edition">source{d} Enterprise Edition</a>
                         </div>
                     </li>
                     <li class="nav-item dropdown">

--- a/src/sass/partials/_layout.scss
+++ b/src/sass/partials/_layout.scss
@@ -1011,6 +1011,7 @@ section.how-for-you {
       text-decoration: none;
     }
   }
+}
 
 .card a.btn:hover {
   color: $white;


### PR DESCRIPTION
According to #424 I capitalized the Edition work on the links on header and footer

![image](https://user-images.githubusercontent.com/14981468/60252826-3c5cab80-98cb-11e9-8a21-47922c4f9875.png)

![image](https://user-images.githubusercontent.com/14981468/60252840-42528c80-98cb-11e9-90f5-83a669880707.png)
