### PR TITLE
Several fixes on landing page

### DIFF
--- a/hugo/layouts/get-started/single.html
+++ b/hugo/layouts/get-started/single.html
@@ -54,7 +54,7 @@
                             </div>
                             <div class="col-sm-12 col-lg-4 text-center">
                                 <a href="https://go.sourced.tech/community-edition-download" class="btn btn-highlight w-100 mb-4">Download source{d}</a>
-                                <a href="https://go.sourced.tech/engine" class="btn btn-highlight w-100 mb-4">Request CE Demo</a>
+                                <a href="https://go.sourced.tech/community-demo" class="btn btn-highlight w-100 mb-4">Request CE Demo</a>
                                 <a href="products/enterprise-edition/#trial" class="btn btn-purple w-100 mb-4">Request EE demo</a>
                             </div>
                         </div>
@@ -69,7 +69,7 @@
                             <div class="col-sm-12 col-lg-4 text-center">
                                 <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100 mb-4">Request EE demo</a>
                                 <a href="news-and-press" class="btn btn-highlight w-100 mb-4">News & Press</a>
-                                <a href="" class="btn btn-purple w-100 mb-4" data-toggle="modal" data-target="#videoModal">1m Video</a>
+                                <a href="" class="btn btn-purple w-100 mb-4" data-toggle="modal" data-target="#videoModal">Watch 1m Video</a>
                             </div>
                         </div>
                     </div>
@@ -85,7 +85,7 @@
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title text-dark">1m Video</h4>
+                <h4 class="modal-title text-dark">source{d}: The Data Platform for your Software Development Life Cycle</h4>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -45,12 +45,10 @@
             <div class="col-sm">
                 <ul>
                     <li><a class="footer-main" href="company">Company</a></li>
-                    <li><a href="company#roadmap">About Us</a></li>
                     <li><a href="why-sourced">Why source{d}</a></li>
                     <li><a href="news-and-press">News and Press</a></li>
-                    <li><a href="company#careers">Careers</a></li>
                     <li><a href="company#offices">Offices</a></li>
-                    <li><a href="company#team">Team</a></li>
+                    <li><a href="company#team">Management</a></li>
                     <li><a href="https://go.sourced.tech/contact">Contact Us</a></li>
                 </ul>
             </div>

--- a/hugo/layouts/partials/header.html
+++ b/hugo/layouts/partials/header.html
@@ -61,11 +61,9 @@
                             Company
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkCom">
-                            <a class="dropdown-item" href="company#roadmap">About</a>
                             <a class="dropdown-item" href="news-and-press">News and Press</a>
-                            <a class="dropdown-item" href="company#careers">Careers</a>
                             <a class="dropdown-item" href="company#offices">Our Offices</a>
-                            <a class="dropdown-item" href="company#team">Team</a>
+                            <a class="dropdown-item" href="company#team">Management</a>
                             <a class="dropdown-item" href="https://go.sourced.tech/contact">Contact Us</a>
                         </div>
                     </li>

--- a/hugo/layouts/products/community-edition/single.html
+++ b/hugo/layouts/products/community-edition/single.html
@@ -23,7 +23,7 @@
                 <p class="text-dark">With source{d} you can start getting answers to tough questions in a matter of minutes with simple SQL queries. source{d} supports all major operating systems (Linux, Windows, MacOS), hosting environments (Cloud or On-premise), version control systems (GitHub, GitLab, Bitbucket, etc) and adapts to different stages of development, workflows and business needs. Enjoy the flexibility to choose whether to work on our built-in interactive web interface, your favorite SQL client, command-line interface or Business Intelligence platform (Tableau, Looker, PowerBI, etc).</p>
                 <div class="text-center mt-5 row">
                     <div class="col-xl-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-xl-6">
                         <a href="https://go.sourced.tech/engine" class="btn btn-highlight w-100">Request a Demo</a>

--- a/hugo/layouts/products/community-edition/single.html
+++ b/hugo/layouts/products/community-edition/single.html
@@ -26,7 +26,7 @@
                         <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-xl-6">
-                        <a href="https://go.sourced.tech/engine" class="btn btn-highlight w-100">Request a Demo</a>
+                        <a href="https://go.sourced.tech/community-demo" class="btn btn-highlight w-100">Request a Demo</a>
                     </div>
                 </div>
             </div>

--- a/hugo/layouts/products/enterprise-edition/single.html
+++ b/hugo/layouts/products/enterprise-edition/single.html
@@ -81,7 +81,7 @@
                         <a href="products/enterprise-edition/#trial" class="btn btn-purple text-white mb-4 w-100">Request a Demo</a>
                     </div>
                     <div class="col-xl-6">
-                        <a href="solutions/talent-assesment-and-management" class="btn btn-highlight w-100">Learn More</a>
+                        <a href="solutions/talent-assessment-and-management" class="btn btn-highlight w-100">Learn More</a>
                     </div>
                 </div>
             </div>

--- a/hugo/layouts/solutions/devops-cloud-native-transformation/single.html
+++ b/hugo/layouts/solutions/devops-cloud-native-transformation/single.html
@@ -70,7 +70,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>
@@ -114,7 +114,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>
@@ -158,7 +158,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>

--- a/hugo/layouts/solutions/engineering-effectiveness-efficiency/single.html
+++ b/hugo/layouts/solutions/engineering-effectiveness-efficiency/single.html
@@ -71,7 +71,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>
@@ -116,7 +116,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>
@@ -161,7 +161,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>

--- a/hugo/layouts/solutions/it-modernization-and-compliance/single.html
+++ b/hugo/layouts/solutions/it-modernization-and-compliance/single.html
@@ -74,7 +74,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>
@@ -118,7 +118,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>
@@ -163,7 +163,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>

--- a/hugo/layouts/solutions/it-modernization-and-compliance/single.html
+++ b/hugo/layouts/solutions/it-modernization-and-compliance/single.html
@@ -42,7 +42,7 @@
     <div class="container text-dark">
         <div class="row pt-5">
             <div class="col-md-6">
-                <h2 class="title-line line-yellow">Technical Debt Assesment</h2>
+                <h2 class="title-line line-yellow">Technical Debt Assessment</h2>
                 <p class="mb-4">Every enterprise accumulates technical debt which will eventually need to be paid back. The longer you wait, the more expensive it will be to fix it. Technical debt not only creates maintenance burdens for engineering teams but also introduces risks (security, quality, reliability, etc) for your business.  source{d} helps you locate and measure your technical debt so that you can prioritize your efforts to get rid of it.</p>
             </div>
             <div class="col-md-6">

--- a/hugo/layouts/solutions/talent-assessment-and-management/single.html
+++ b/hugo/layouts/solutions/talent-assessment-and-management/single.html
@@ -71,7 +71,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>
@@ -115,7 +115,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>
@@ -159,7 +159,7 @@
             <div class="col-xl-6 offset-xl-3">
                 <div class="row">
                     <div class="col-lg-6">
-                        <a href="https://go.sourced.tech/engine-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
+                        <a href="https://go.sourced.tech/community-edition-download" class="btn btn-purple text-white mb-4 w-100">Download source{d}</a>
                     </div>
                     <div class="col-lg-6">
                         <a href="products/enterprise-edition/#trial" class="btn btn-highlight w-100">Request a Demo</a>


### PR DESCRIPTION
fix #438
fix #435

According to #435, this PR updates the landing with several changes:

Enterprise edition page

- Under  "Talent Assessment & Management" the "learn more" button currently point to a "404 Not Found" instead of https://sourced.tech/solutions/talent-assessment-and-management/ (missing an s at assessment) 

Community edition page

- Update the "download source{d}" button to link to https://go.sourced.tech/community-edition-download instead of https://go.sourced.tech/engine-download

Manager get started tab 

- Update the "Request CE demo" link to point to https://go.sourced.tech/community-demo 

Executives get started tab 

- Replace the "1m video" by "Watch 1m Video" and update the title in the pop up title to "source{d}: The Data Platform for your Software Development Life Cycle' 

IT Modernization & Compliance

- Update ALL the "download source{d}" buttons to link to https://go.sourced.tech/community-edition-download instead of https://go.sourced.tech/engine-download

DevOps & Cloud Native Transformation

- Update ALL the "download source{d}" buttons to link to https://go.sourced.tech/community-edition-download instead of https://go.sourced.tech/engine-download

Engineering Effectiveness & Efficiency

- Update ALL the "download source{d}" buttons to link to https://go.sourced.tech/community-edition-download instead of https://go.sourced.tech/engine-download

Talent Assesment & Management

- Update ALL the "download source{d}" buttons to link to https://go.sourced.tech/community-edition-download instead of https://go.sourced.tech/engine-download

Header & Footer

- Under Company, remove About from both Header and Footer
- Replace "Team" by "Management"
- Careers links to "offices" it's of Openings 