### PR TITLE
Use a compatible version of drone helm plugin

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,7 +60,7 @@ docker_image_api: &docker_image_api
   dockerfile: Dockerfile.api
 
 helm_deploy: &helm_deploy
-  image: quay.io/ipedrazas/drone-helm
+  image: quay.io/ipedrazas/drone-helm:master-9b37211
   skip_tls_verify: true
   chart: ./helm-charts/landing
   release: landing


### PR DESCRIPTION
latest is not compatible with our helm tiller as it uses a client too
new

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>