### PR TITLE
Replacing Blog announcement on the homepage

### DIFF
--- a/hugo.config.yaml
+++ b/hugo.config.yaml
@@ -48,5 +48,5 @@ params:
         linkedin: "sourced"
     # fixed web announcment; if one of its properties is empty, it won't be displayed.
     announcement:
-        title: "source{d} named 2019 Gartner Cool Vendor"
-        url: "https://blog.sourced.tech/post/source-d-is-officially-cool-according-to-gartner/"
+        title: "Announcing source{d} Enterprise Edition: A scalable, secure and extensible data platform for enterprises"
+        url: "https://blog.sourced.tech/post/announcing-source-d-enterprise-edition-a-scalable-secure-and-extensible-data-platform-for-enterprises/"

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -27,7 +27,7 @@
 <section class="news pt-3 pb-3">
     {{ if and (default false .Site.Params.announcement.title) (default false .Site.Params.announcement.url) }}
         <div class="container">
-            <h4 class="text-dark m-0">
+            <h4 class="text-dark text-truncate m-0">
                 <span class="badge badge-warning">New</span>
                 <a class="badge-text" href="{{ .Site.Params.announcement.url }}">
                     {{ .Site.Params.announcement.title }}


### PR DESCRIPTION
As requested on [#1403 issue](https://github.com/src-d/backlog/issues/1403) from the Backlog, I manually added the new highlighted post on the homepage:

![image](https://user-images.githubusercontent.com/14981468/60905286-062d0d80-a275-11e9-97ae-6cd49e38b842.png)


Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>