### PR TITLE
Adding Cookiebot consent banner

### DIFF
--- a/hugo/layouts/legal/single.html
+++ b/hugo/layouts/legal/single.html
@@ -128,6 +128,17 @@
     </div>
 </section>
 
+<section id="cookies" class="text-dark pb-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h3 class="title-line line-yellow">Cookie Declaration</h3>
+                <script id="CookieDeclaration" src="https://consent.cookiebot.com/bebaec9f-3b51-4686-adf1-1f3bb76dec15/cd.js" type="text/javascript" async></script>
+            </div>
+        </div>
+    </div>
+</section>
+
 {{ partial "footer.html" }}
 </body>
 </html>

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -26,6 +26,7 @@
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="bebaec9f-3b51-4686-adf1-1f3bb76dec15" type="text/javascript" async></script>
 
     <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
This is related to the [issue #1405](https://github.com/src-d/backlog/issues/1405) from the Backlog.

I added the scripts for the cookie consent banner. I can't check if it is working on the localhost, so I guess we need to upload it to staging at least to see if it is working.

Also I wasn't sure if we need to add the `data-cookieconsent` to any script on the site:

![image](https://user-images.githubusercontent.com/14981468/60906158-d121ba80-a276-11e9-81ec-24543cd649d2.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>