### PR TITLE
Update deployment to work on Helm 2.14.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,7 +60,7 @@ docker_image_api: &docker_image_api
   dockerfile: Dockerfile.api
 
 helm_deploy: &helm_deploy
-  image: quay.io/ipedrazas/drone-helm:master-9b37211
+  image: quay.io/ipedrazas/drone-helm@sha256:43a6e6f907e68925fdb46601981242d68c41eb3e67154d8675627e19fd78f216
   skip_tls_verify: true
   chart: ./helm-charts/landing
   release: landing


### PR DESCRIPTION
This upgrades the Helm plugin to work with the latest Helm version.