### PR TITLE
Fixing alignment on Company page position cards

### DIFF
--- a/hugo/layouts/mustache-tpls/positions.tpl
+++ b/hugo/layouts/mustache-tpls/positions.tpl
@@ -5,13 +5,15 @@
     [[#positions]]
         <div class="col-md-6 col-lg-4 mb-4">
             <div class="card text-white orange h-100">
-                <div class="card-body p-5">
+                <div class="card-body d-flex flex-column p-5">
                     <p class="card-intro">[[team]]</p>
                     <h3 class="title-line line-yellow">
                         [[#rmHyphen]][[title]][[/rmHyphen]]
                     </h3>
                     <p>[[location]]<br>[[commitment]]</p>
-                    <a href="[[url]]" class="btn btn-secondary-light w-100">View and Apply</a>
+                    <div class="mt-auto">
+                        <a href="[[url]]" class="btn btn-secondary-light w-100">View and Apply</a>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
As requested on #337, here is a fix to make the buttons on the position cards on the company page to align on the bottom.

![image](https://user-images.githubusercontent.com/14981468/62107311-a50ebd80-b2a7-11e9-9b2b-ac5507b5b303.png)

Notice that right now it cannot be seen on the page itself as there are no current open positions.

Thank you. 

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>