### PR TITLE
Adding Slack icon to the Community page

### DIFF
--- a/hugo/layouts/community/single.html
+++ b/hugo/layouts/community/single.html
@@ -28,7 +28,7 @@
             </div>
         </div>
         <div class="row mt-5 text-center text-md-left">
-            <div class="col-6 col-lg-3 network mb-5">
+            <div class="col-6 col-lg-4 network mb-5">
                 <div class="row">
                     <div class="col-md-3">
                         <span class="ic icon-git"></span>
@@ -40,7 +40,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-6 col-lg-3 network mb-5">
+            <div class="col-6 col-lg-4 network mb-5">
                 <div class="row">
                     <div class="col-md-3">
                         <span class="ic icon-twi"></span>
@@ -52,7 +52,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-6 col-lg-3 network mb-5">
+            <div class="col-6 col-lg-4 network mb-5">
                 <div class="row">
                     <div class="col-md-3">
                         <span class="ic icon-you"></span>
@@ -64,7 +64,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-6 col-lg-3 network mb-5">
+            <div class="col-6 col-lg-4 network mb-5">
                 <div class="row">
                     <div class="col-md-3">
                         <span class="ic icon-lin"></span>
@@ -76,7 +76,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-6 col-lg-3 network mb-5">
+            <div class="col-6 col-lg-4 network mb-5">
                 <div class="row">
                     <div class="col-md-3">
                         <span class="ic icon-sli"></span>
@@ -88,7 +88,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-6 col-lg-3 network mb-5 mb-lg-0">
+            <div class="col-6 col-lg-4 network mb-5 mb-lg-0">
                 <div class="row">
                     <div class="col-md-3">
                         <span class="ic icon-fac"></span>
@@ -100,7 +100,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-6 col-lg-3 network mb-5 mb-lg-0">
+            <div class="col-6 col-lg-4 network mb-5 mb-lg-0">
                 <div class="row">
                     <div class="col-md-3">
                         <span class="ic icon-discourse"></span>
@@ -112,7 +112,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-6 col-lg-3 network mb-5 mb-lg-0">
+            <div class="col-6 col-lg-4 network mb-5 mb-lg-0">
                 <div class="row">
                     <div class="col-md-3">
                         <span class="ic icon-med"></span>
@@ -120,6 +120,18 @@
                     <div class="col-md-9">
                         <a class="nostyle" href="https://medium.com/sourcedtech/">
                             <h4 class="text-dark mt-3">Medium</h4>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-6 col-lg-4 network mb-5 mb-lg-0">
+                <div class="row">
+                    <div class="col-md-3">
+                        <span class="ic icon-slack"></span>
+                    </div>
+                    <div class="col-md-9">
+                        <a class="nostyle" href="https://src-d.slack.com">
+                            <h4 class="text-dark mt-3">Slack</h4>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
This PR adds a Slack icon to the community page as requested on #454. Notice that with the change I reordered the columns to 3 on the larger screen size as now there are 9 icons.

![image](https://user-images.githubusercontent.com/14981468/62107795-b0aeb400-b2a8-11e9-813d-aa1c7998e5bf.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>