### PR TITLE
Adding the AddThis script to all landing pages

### DIFF
--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -72,6 +72,9 @@
     </div>
 </footer>
 
+<!-- AddThis Integration -->
+<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5c8be142d97248ba"></script>
+
 <!-- Pardot integration -->
 <script type="text/javascript">
 piAId = '579561';


### PR DESCRIPTION
This PR is related to the issue [#125](https://github.com/src-d/devrel/issues/125) on devrel.

It includes the AddThis icons for sharing any page on the site.

![image](https://user-images.githubusercontent.com/14981468/66300500-b6062b80-e8f5-11e9-86d8-29b894094399.png)

![image](https://user-images.githubusercontent.com/14981468/66300534-c4544780-e8f5-11e9-9d6f-b5596d6bdecd.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>