### PR TITLE
Updating announcement to show the new ebook

### DIFF
--- a/hugo.config.yaml
+++ b/hugo.config.yaml
@@ -48,5 +48,5 @@ params:
         linkedin: "sourced"
     # fixed web announcment; if one of its properties is empty, it won't be displayed.
     announcement:
-        title: "Announcing source{d} Enterprise Edition: A scalable, secure and extensible data platform for enterprises"
-        url: "https://blog.sourced.tech/post/announcing-source-d-enterprise-edition-a-scalable-secure-and-extensible-data-platform-for-enterprises/"
+        title: "Download our new Machine Learning for Software Development Analytics Ebook"
+        url: "https://go.sourced.tech/ml-ebook"


### PR DESCRIPTION
This PR is related to the issue #468.

It updates the announcement on the website:

![image](https://user-images.githubusercontent.com/14981468/66301764-01213e00-e8f8-11e9-921b-68cf082b26f4.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>